### PR TITLE
Added json extensions and tests

### DIFF
--- a/src/Ardalis.Extensions/Ardalis.Extensions.csproj
+++ b/src/Ardalis.Extensions/Ardalis.Extensions.csproj
@@ -26,4 +26,8 @@
   <ItemGroup>
     <None Include="LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+  </ItemGroup>
 </Project>

--- a/src/Ardalis.Extensions/StringExtensions.cs
+++ b/src/Ardalis.Extensions/StringExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json;
 
 namespace Ardalis.Extensions
 {
@@ -41,6 +42,32 @@ namespace Ardalis.Extensions
             }
 
             return int.Parse(input);
+        }
+
+        /// <summary>
+        /// Converts JSON string to the specified type
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="t"></param>
+        /// <returns></returns>
+        public static T FromJsonString<T>(this string t)
+        {
+            var value = JsonSerializer.Deserialize<T>(t);
+
+            return (T)Convert.ChangeType(value, typeof(T));
+        }
+
+        /// <summary>
+        /// Converts a Type to a JSON string
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="t"></param>
+        /// <returns></returns>
+        public static string ToJsonString<T>(this T t)
+        {
+            var value = JsonSerializer.Serialize(t);
+
+            return value;
         }
     }
 }

--- a/tests/Ardalis.Extensions.UnitTests/Ardalis.Extensions.UnitTests.csproj
+++ b/tests/Ardalis.Extensions.UnitTests/Ardalis.Extensions.UnitTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Ardalis.Extensions.UnitTests/StringExtensionsJson.cs
+++ b/tests/Ardalis.Extensions.UnitTests/StringExtensionsJson.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Ardalis.Extensions.UnitTests
+{
+    public class UserTestClass
+    {
+        public string Name { get; set; }
+    }
+
+    public class StringExtensionsJson
+    {
+        public static IEnumerable<object[]> UserData
+        {
+            get
+            {
+                yield return new object[] { new UserTestClass { Name = "John" } };
+            }
+        }
+
+
+        [Theory]
+        [InlineData("{ \"Name\": \"John\" }")]
+        public void ReturnsAnObjectFromJsonString(string input)
+        {
+            var result = input.FromJsonString<UserTestClass>();
+
+            Assert.Equal(new UserTestClass { Name = "John" }.Name, result.Name);
+        }
+
+        [Theory]
+        [MemberData(nameof(UserData))]
+        public void ReturnsJsonStringFromAnObject(UserTestClass input)
+        {
+            string result = input.ToJsonString();
+
+            Assert.Equal("{\"Name\":\"John\"}", result);
+        }
+    }
+}


### PR DESCRIPTION
Hi. I added two new extension methods for JSON operations. They can be used like that;


**UserModel.cs**

```cs
public class UserModel
 {
        public string Name { get; set; }
}
```

**String To Entity Conversion**

```cs
UserModel user = "{ \"Name\": \"John\" }".FromJsonString<UserModel>();
```

**Entity to String Conversion**

```cs
UserModel user = new() { Name = "John" };

string jsonString = user.ToJsonString();
```

I also added test cases for both methods.