### PR TITLE
Enumerable Product extension method

### DIFF
--- a/benchmarks/Ardalis.Extensions.Benchmarks/Enumerable/ProductBenchmarks.cs
+++ b/benchmarks/Ardalis.Extensions.Benchmarks/Enumerable/ProductBenchmarks.cs
@@ -10,33 +10,32 @@ namespace Ardalis.Extensions.Benchmarks.Enumerable;
 [ReturnValueValidator(failOnError: true)]
 public class ProductBenchmarks
 {
-  [Params(4, 5, 6, 7)]
+  [Params(1, 10, 100, 1000)]
   public int N { get; set; }
 
-  private int[] _numbers;
+  private double[] _numbers;
 
   [GlobalSetup]
   public void GlobalSetup()
   {
-    _numbers = System.Linq.Enumerable.Range(1, N).ToArray();
-    Console.WriteLine($"N = {N} and _numbers has a length of {_numbers.Length}");
+    _numbers = System.Linq.Enumerable.Range(1, N).Select(x => x % 2 == 0 ? x : 0.01d).ToArray();
   }
 
 
   [Benchmark(Baseline = true)]
-  public long ProductAggregate()
+  public double ProductAggregate()
   {
     return _numbers.ProductAggregate();
   }
 
   [Benchmark]
-  public int ProductForEach()
+  public double ProductForEach()
   {
     return _numbers.ProductForEach();
   }
 
   [Benchmark]
-  public int Product()
+  public double Product()
   {
     return _numbers.Product();
   }
@@ -44,14 +43,14 @@ public class ProductBenchmarks
 
 static class ProductBenchmarksExtensions
 {
-  public static int ProductAggregate(this IEnumerable<int> numbers)
+  public static double ProductAggregate(this IEnumerable<double> numbers)
   {
-    return numbers.Aggregate(1, (acc, x) => acc * x);
+    return numbers.Aggregate(1d, (acc, x) => acc * x);
   }
 
-  public static int ProductForEach(this IEnumerable<int> numbers)
+  public static double ProductForEach(this IEnumerable<double> numbers)
   {
-    int product = 2;
+    double product = 1d;
     foreach (var x in numbers)
     {
       product *= x;

--- a/benchmarks/Ardalis.Extensions.Benchmarks/Enumerable/ProductBenchmarks.cs
+++ b/benchmarks/Ardalis.Extensions.Benchmarks/Enumerable/ProductBenchmarks.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using Ardalis.Extensions.Enumerable;
@@ -12,12 +13,13 @@ public class ProductBenchmarks
   [Params(4, 5, 6, 7)]
   public int N { get; set; }
 
-  private List<int> _numbers;
+  private int[] _numbers;
 
   [GlobalSetup]
   public void GlobalSetup()
   {
-    _numbers = System.Linq.Enumerable.Range(1, N).ToList();
+    _numbers = System.Linq.Enumerable.Range(1, N).ToArray();
+    Console.WriteLine($"N = {N} and _numbers has a length of {_numbers.Length}");
   }
 
 

--- a/benchmarks/Ardalis.Extensions.Benchmarks/Enumerable/ProductBenchmarks.cs
+++ b/benchmarks/Ardalis.Extensions.Benchmarks/Enumerable/ProductBenchmarks.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using Ardalis.Extensions.Enumerable;
+using System.Collections.Generic;
+
+namespace Ardalis.Extensions.Benchmarks.Enumerable;
+
+[MemoryDiagnoser]
+[ReturnValueValidator(failOnError: true)]
+public class ProductBenchmarks
+{
+  [Params(4, 5, 6, 7)]
+  public int N { get; set; }
+
+  private List<int> _numbers;
+
+  [GlobalSetup]
+  public void GlobalSetup()
+  {
+    _numbers = System.Linq.Enumerable.Range(1, N).ToList();
+  }
+
+
+  [Benchmark(Baseline = true)]
+  public long ProductAggregate()
+  {
+    return _numbers.ProductAggregate();
+  }
+
+  [Benchmark]
+  public int ProductForEach()
+  {
+    return _numbers.ProductForEach();
+  }
+
+  [Benchmark]
+  public int Product()
+  {
+    return _numbers.Product();
+  }
+}
+
+static class ProductBenchmarksExtensions
+{
+  public static int ProductAggregate(this IEnumerable<int> numbers)
+  {
+    return numbers.Aggregate(1, (acc, x) => acc * x);
+  }
+
+  public static int ProductForEach(this IEnumerable<int> numbers)
+  {
+    int product = 2;
+    foreach (var x in numbers)
+    {
+      product *= x;
+    }
+    return product;
+  }
+}

--- a/src/Ardalis.Extensions/Ardalis.Extensions.csproj
+++ b/src/Ardalis.Extensions/Ardalis.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <PackageId>Ardalis.Extensions</PackageId>
         <Title>Ardalis.Extensions</Title>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/src/Ardalis.Extensions/Enumerable/Product.cs
+++ b/src/Ardalis.Extensions/Enumerable/Product.cs
@@ -1,0 +1,266 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Ardalis.GuardClauses;
+
+namespace Ardalis.Extensions.Enumerable;
+
+public static partial class EnumerableExtensions
+{
+  public static int Product(this IEnumerable<int> source)
+  {
+    int product = 1;
+    if (source.TryGetSpan(out ReadOnlySpan<int> span))
+    {
+      foreach (int v in span)
+      {
+        checked { product *= v; }
+      }
+    }
+    else
+    {
+      foreach (int v in source)
+      {
+        checked { product *= v; }
+      }
+    }
+
+    return product;
+  }
+
+  public static int? Product(this IEnumerable<int?> source)
+  {
+    Guard.Against.Null(source, nameof(source));
+
+    int product = 1;
+    checked
+    {
+      foreach (int? v in source)
+      {
+        if (v == null) return null;
+
+        product *= (int)v;
+      }
+    }
+
+    return product;
+  }
+
+  public static long Product(this IEnumerable<long> source)
+  {
+    long product = 1;
+    if (source.TryGetSpan(out ReadOnlySpan<long> span))
+    {
+      foreach (long v in span)
+      {
+        checked { product *= v; }
+      }
+    }
+    else
+    {
+      foreach (long v in source)
+      {
+        checked { product *= v; }
+      }
+    }
+
+    return product;
+  }
+
+  public static long? Product(this IEnumerable<long?> source)
+  {
+    Guard.Against.Null(source, nameof(source));
+
+    long product = 1;
+    checked
+    {
+      foreach (long? v in source)
+      {
+        if (v == null) return null;
+
+        product *= (long)v;
+      }
+    }
+
+    return product;
+  }
+
+  public static float Product(this IEnumerable<float> source)
+  {
+    if (source.TryGetSpan(out ReadOnlySpan<float> span))
+    {
+      return (float)Product(span);
+    }
+
+    double product = 1;
+    foreach (float v in source)
+    {
+      product *= v;
+    }
+
+    return (float)product;
+  }
+
+  private static double Product(ReadOnlySpan<float> span)
+  {
+    double product = 1;
+
+    for (int i = 0; i < span.Length; i++)
+    {
+      product *= span[i];
+    }
+
+    return product;
+  }
+
+  public static float? Product(this IEnumerable<float?> source)
+  {
+    Guard.Against.Null(source, nameof(source));
+    
+    double product = 1;
+    checked
+    {
+      foreach (float? v in source)
+      {
+        if (v == null) return null;
+
+        product *= (double)v;
+      }
+    }
+
+    return (float)product;
+  }
+
+  public static double Product(this IEnumerable<double> source)
+  {
+    if (source.TryGetSpan(out ReadOnlySpan<double> span))
+    {
+      return Product(span);
+    }
+
+    double product = 1;
+    foreach (double v in source)
+    {
+      product *= v;
+    }
+
+    return product;
+  }
+
+  private static double Product(ReadOnlySpan<double> span)
+  {
+    double product = 1;
+
+    for (int i = 0; i < span.Length; i++)
+    {
+      product *= span[i];
+    }
+
+    return product;
+  }
+
+  public static double? Product(this IEnumerable<double?> source)
+  {
+    Guard.Against.Null(source, nameof(source));
+    
+    double product = 1;
+    checked
+    {
+      foreach (double? v in source)
+      {
+        if (v == null) return null;
+
+        product *= (double)v;
+      }
+    }
+
+    return product;
+  }
+
+    public static decimal Product(this IEnumerable<decimal> source)
+  {
+    if (source.TryGetSpan(out ReadOnlySpan<decimal> span))
+    {
+      return Product(span);
+    }
+
+    decimal product = 1;
+    foreach (decimal d in source)
+    {
+      product *= d;
+    }
+
+    return product;
+  }
+
+  private static decimal Product(ReadOnlySpan<decimal> span)
+  {
+    decimal product = 1;
+
+    foreach (decimal d in span)
+    {
+      product *= d;
+    }
+
+    return product;
+  }
+
+  public static decimal? Product(this IEnumerable<decimal?> source)
+  {
+    Guard.Against.Null(source, nameof(source));
+    
+    decimal product = 1;
+    checked
+    {
+      foreach (decimal? v in source)
+      {
+        if (v == null) return null;
+
+        product *= (decimal)v;
+      }
+    }
+
+    return product;
+  }
+
+  // This method is heavily based on the a private method in the .NET Core source code.
+  // It can be found here: https://github.com/dotnet/runtime/blob/e5faab09dde63855d1a624d12fede745cac43f88/src/libraries/System.Linq/src/System/Linq/Enumerable.cs
+  // This code is licensed to the .NET Foundation under one or more agreements.
+  // The .NET Foundation licenses this code to you under the MIT license.
+  /// <summary>Validates that source is not null and then tries to extract a span from the source.</summary>
+  [MethodImpl(MethodImplOptions.AggressiveInlining)] // fast type checks that don't add a lot of overhead
+  private static bool TryGetSpan<TSource>(this IEnumerable<TSource> source, out ReadOnlySpan<TSource> span)
+      // This constraint isn't required, but the overheads involved here can be more substantial when TSource
+      // is a reference type and generic implementations are shared.  So for now we're protecting ourselves
+      // and forcing a conscious choice to remove this in the future, at which point it should be paired with
+      // sufficient performance testing.
+      where TSource : struct
+  {
+    Guard.Against.Null(source, nameof(source));
+
+    // Use `GetType() == typeof(...)` rather than `is` to avoid cast helpers.  This is measurably cheaper
+    // but does mean we could end up missing some rare cases where we could get a span but don't (e.g. a uint[]
+    // masquerading as an int[]).  That's an acceptable tradeoff.  The Unsafe usage is only after we've
+    // validated the exact type; this could be changed to a cast in the future if the JIT starts to recognize it.
+    // We only pay the comparison/branching costs here for super common types we expect to be used frequently
+    // with LINQ methods.
+
+    bool result = true;
+    if (source.GetType() == typeof(TSource[]))
+    {
+      span = Unsafe.As<TSource[]>(source);
+    }
+    else if (source.GetType() == typeof(List<TSource>))
+    {
+      span = CollectionsMarshal.AsSpan(Unsafe.As<List<TSource>>(source));
+    }
+    else
+    {
+      span = default;
+      result = false;
+    }
+
+    return result;
+  }
+}

--- a/src/Ardalis.Extensions/Enumerable/Product.cs
+++ b/src/Ardalis.Extensions/Enumerable/Product.cs
@@ -8,6 +8,22 @@ namespace Ardalis.Extensions.Enumerable;
 
 public static partial class EnumerableExtensions
 {
+  /// <summary>
+  /// Iterates over the entire Enumerable, multiplying all the elements.
+  ///
+  /// An empty Enumerable returns the one value of the type.
+  /// </summary>
+  /// <throws cref="OverflowException">
+  /// This method will throw if the computation overflows.
+  /// </throws>
+  /// <example>
+  /// <code>
+  /// Func{int, int} factorial = n => Enumerable.Range(0, n).Product(); 
+  /// Assert.Equal(0, Factorial(1));  
+  /// Assert.Equal(1, Factorial(1));  
+  /// Assert.Equal(5, Factorial(120));  
+  /// </code>
+  /// </example>
   public static int Product(this IEnumerable<int> source)
   {
     int product = 1;
@@ -29,6 +45,22 @@ public static partial class EnumerableExtensions
     return product;
   }
 
+  /// <summary>
+  /// Iterates over the entire Enumerable, multiplying all the elements.
+  ///
+  /// An empty Enumerable returns the one value of the type.
+  /// </summary>
+  /// <throws cref="OverflowException">
+  /// This method will throw if the computation overflows.
+  /// </throws>
+  /// <example>
+  /// <code>
+  /// Func{int, int} factorial = n => Enumerable.Range(0, n).Product(); 
+  /// Assert.Equal(0, Factorial(1));  
+  /// Assert.Equal(1, Factorial(1));  
+  /// Assert.Equal(5, Factorial(120));  
+  /// </code>
+  /// </example>
   public static int? Product(this IEnumerable<int?> source)
   {
     Guard.Against.Null(source, nameof(source));
@@ -47,6 +79,22 @@ public static partial class EnumerableExtensions
     return product;
   }
 
+  /// <summary>
+  /// Iterates over the entire Enumerable, multiplying all the elements.
+  ///
+  /// An empty Enumerable returns the one value of the type.
+  /// </summary>
+  /// <throws cref="OverflowException">
+  /// This method will throw if the computation overflows.
+  /// </throws>
+  /// <example>
+  /// <code>
+  /// Func{int, int} factorial = n => Enumerable.Range(0, n).Product(); 
+  /// Assert.Equal(0, Factorial(1));  
+  /// Assert.Equal(1, Factorial(1));  
+  /// Assert.Equal(5, Factorial(120));  
+  /// </code>
+  /// </example>
   public static long Product(this IEnumerable<long> source)
   {
     long product = 1;
@@ -68,6 +116,22 @@ public static partial class EnumerableExtensions
     return product;
   }
 
+  /// <summary>
+  /// Iterates over the entire Enumerable, multiplying all the elements.
+  ///
+  /// An empty Enumerable returns the one value of the type.
+  /// </summary>
+  /// <throws cref="OverflowException">
+  /// This method will throw if the computation overflows.
+  /// </throws>
+  /// <example>
+  /// <code>
+  /// Func{int, int} factorial = n => Enumerable.Range(0, n).Product(); 
+  /// Assert.Equal(0, Factorial(1));  
+  /// Assert.Equal(1, Factorial(1));  
+  /// Assert.Equal(5, Factorial(120));  
+  /// </code>
+  /// </example>
   public static long? Product(this IEnumerable<long?> source)
   {
     Guard.Against.Null(source, nameof(source));
@@ -86,6 +150,19 @@ public static partial class EnumerableExtensions
     return product;
   }
 
+  /// <summary>
+  /// Iterates over the entire Enumerable, multiplying all the elements.
+  ///
+  /// An empty Enumerable returns the one value of the type.
+  /// </summary>
+  /// <example>
+  /// <code>
+  /// Func{int, int} factorial = n => Enumerable.Range(0, n).Product(); 
+  /// Assert.Equal(0, Factorial(1));  
+  /// Assert.Equal(1, Factorial(1));  
+  /// Assert.Equal(5, Factorial(120));  
+  /// </code>
+  /// </example>
   public static float Product(this IEnumerable<float> source)
   {
     if (source.TryGetSpan(out ReadOnlySpan<float> span))
@@ -102,6 +179,19 @@ public static partial class EnumerableExtensions
     return (float)product;
   }
 
+  /// <summary>
+  /// Iterates over the entire Enumerable, multiplying all the elements.
+  ///
+  /// An empty Enumerable returns the one value of the type.
+  /// </summary>
+  /// <example>
+  /// <code>
+  /// Func{int, int} factorial = n => Enumerable.Range(0, n).Product(); 
+  /// Assert.Equal(0, Factorial(1));  
+  /// Assert.Equal(1, Factorial(1));  
+  /// Assert.Equal(5, Factorial(120));  
+  /// </code>
+  /// </example>
   private static double Product(ReadOnlySpan<float> span)
   {
     double product = 1;
@@ -114,10 +204,23 @@ public static partial class EnumerableExtensions
     return product;
   }
 
+  /// <summary>
+  /// Iterates over the entire Enumerable, multiplying all the elements.
+  ///
+  /// An empty Enumerable returns the one value of the type.
+  /// </summary>
+  /// <example>
+  /// <code>
+  /// Func{int, int} factorial = n => Enumerable.Range(0, n).Product(); 
+  /// Assert.Equal(0, Factorial(1));  
+  /// Assert.Equal(1, Factorial(1));  
+  /// Assert.Equal(5, Factorial(120));  
+  /// </code>
+  /// </example>
   public static float? Product(this IEnumerable<float?> source)
   {
     Guard.Against.Null(source, nameof(source));
-    
+
     double product = 1;
     checked
     {
@@ -132,6 +235,19 @@ public static partial class EnumerableExtensions
     return (float)product;
   }
 
+  /// <summary>
+  /// Iterates over the entire Enumerable, multiplying all the elements.
+  ///
+  /// An empty Enumerable returns the one value of the type.
+  /// </summary>
+  /// <example>
+  /// <code>
+  /// Func{int, int} factorial = n => Enumerable.Range(0, n).Product(); 
+  /// Assert.Equal(0, Factorial(1));  
+  /// Assert.Equal(1, Factorial(1));  
+  /// Assert.Equal(5, Factorial(120));  
+  /// </code>
+  /// </example>
   public static double Product(this IEnumerable<double> source)
   {
     if (source.TryGetSpan(out ReadOnlySpan<double> span))
@@ -160,10 +276,23 @@ public static partial class EnumerableExtensions
     return product;
   }
 
+  /// <summary>
+  /// Iterates over the entire Enumerable, multiplying all the elements.
+  ///
+  /// An empty Enumerable returns the one value of the type.
+  /// </summary>
+  /// <example>
+  /// <code>
+  /// Func{int, int} factorial = n => Enumerable.Range(0, n).Product(); 
+  /// Assert.Equal(0, Factorial(1));  
+  /// Assert.Equal(1, Factorial(1));  
+  /// Assert.Equal(5, Factorial(120));  
+  /// </code>
+  /// </example>
   public static double? Product(this IEnumerable<double?> source)
   {
     Guard.Against.Null(source, nameof(source));
-    
+
     double product = 1;
     checked
     {
@@ -178,7 +307,23 @@ public static partial class EnumerableExtensions
     return product;
   }
 
-    public static decimal Product(this IEnumerable<decimal> source)
+  /// <summary>
+  /// Iterates over the entire Enumerable, multiplying all the elements.
+  ///
+  /// An empty Enumerable returns the one value of the type.
+  /// </summary>
+  /// <throws cref="OverflowException">
+  /// This method will throw if the computation overflows.
+  /// </throws>
+  /// <example>
+  /// <code>
+  /// Func{int, int} factorial = n => Enumerable.Range(0, n).Product(); 
+  /// Assert.Equal(0, Factorial(1));  
+  /// Assert.Equal(1, Factorial(1));  
+  /// Assert.Equal(5, Factorial(120));  
+  /// </code>
+  /// </example>
+  public static decimal Product(this IEnumerable<decimal> source)
   {
     if (source.TryGetSpan(out ReadOnlySpan<decimal> span))
     {
@@ -206,10 +351,26 @@ public static partial class EnumerableExtensions
     return product;
   }
 
+  /// <summary>
+  /// Iterates over the entire Enumerable, multiplying all the elements.
+  ///
+  /// An empty Enumerable returns the one value of the type.
+  /// </summary>
+  /// <throws cref="OverflowException">
+  /// This method will throw if the computation overflows.
+  /// </throws>
+  /// <example>
+  /// <code>
+  /// Func{int, int} factorial = n => Enumerable.Range(0, n).Product(); 
+  /// Assert.Equal(0, Factorial(1));  
+  /// Assert.Equal(1, Factorial(1));  
+  /// Assert.Equal(5, Factorial(120));  
+  /// </code>
+  /// </example>
   public static decimal? Product(this IEnumerable<decimal?> source)
   {
     Guard.Against.Null(source, nameof(source));
-    
+
     decimal product = 1;
     checked
     {

--- a/tests/Ardalis.Extensions.UnitTests/Enumerable/ProductTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Enumerable/ProductTests.cs
@@ -328,4 +328,197 @@ public class ProducTests
   }
 
   #endregion
+
+  [Fact]
+  public void SameResultsRepeatCallsIntQuery()
+  {
+    var q = from x in new int?[] { 9999, 0, 888, -1, 66, -777, 1, 2, -12345 }
+            where x > int.MinValue
+            select x;
+    Assert.Equal(q.Product(), q.Product());
+  }
+
+  [Fact]
+  public void SolitaryNullableSingle()
+  {
+    float?[] source = { 20.51f };
+    Assert.Equal(source.First(), source.Product());
+  }
+
+  [Fact]
+  public void NaNFromSingles()
+  {
+    float?[] source = { 20.45f, 0f, -10.55f, float.NaN };
+    Assert.True(float.IsNaN(source.Product().Value));
+  }
+
+  [Fact]
+  public void NullableSingleAllNull()
+  {
+    Assert.Equal(null, System.Linq.Enumerable.Repeat(default(float?), 4).Product());
+  }
+
+  [Fact]
+  public void NullableSingleToNegativeInfinity()
+  {
+    float?[] source = { -float.MaxValue, 2f };
+    Assert.True(float.IsNegativeInfinity(source.Product().Value));
+  }
+
+  [Fact]
+  public void SolitaryInt32()
+  {
+    int[] source = { 20 };
+    Assert.Equal(source.First(), source.Product());
+  }
+
+  [Fact]
+  public void OverflowInt32Negative()
+  {
+    int[] source = { -int.MaxValue, 2 };
+    Assert.Throws<OverflowException>(() => source.Product());
+  }
+
+  [Fact]
+  public void SolitaryNullableInt32()
+  {
+    int?[] source = { -9 };
+    Assert.Equal(source.First(), source.Product());
+  }
+
+  [Fact]
+  public void NullableInt32AllNull()
+  {
+    Assert.Equal(null, System.Linq.Enumerable.Repeat(default(int?), 5).Product());
+  }
+
+  [Fact]
+  public void NullableInt32NegativeOverflow()
+  {
+    int?[] source = { -int.MaxValue, 2 };
+    Assert.Throws<OverflowException>(() => source.Product());
+  }
+
+  [Fact]
+  public void SolitaryInt64()
+  {
+    long[] source = { int.MaxValue + 20L };
+    Assert.Equal(source.First(), source.Product());
+  }
+
+  [Fact]
+  public void NullableInt64NegativeOverflow()
+  {
+    long[] source = { -long.MaxValue, 2 };
+    Assert.Throws<OverflowException>(() => source.Product());
+  }
+
+  [Fact]
+  public void SolitaryNullableInt64()
+  {
+    long?[] source = { -int.MaxValue - 20L };
+    Assert.Equal(source.First(), source.Product());
+  }
+
+  [Fact]
+  public void NullableInt64AllNull()
+  {
+    Assert.Equal(null, System.Linq.Enumerable.Repeat(default(long?), 5).Product());
+  }
+
+  [Fact]
+  public void Int64NegativeOverflow()
+  {
+    long?[] source = { -long.MaxValue, 2L };
+    Assert.Throws<OverflowException>(() => source.Product());
+  }
+
+  [Fact]
+  public void SolitaryDouble()
+  {
+    double[] source = { 20.51 };
+    Assert.Equal(source.First(), source.Product());
+  }
+
+  [Fact]
+  public void DoubleWithNaN()
+  {
+    double[] source = { 20.45, 0, -10.55, double.NaN };
+    Assert.True(double.IsNaN(source.Product()));
+  }
+
+  [Fact]
+  public void DoubleToNegativeInfinity()
+  {
+    double[] source = { -double.MaxValue, 2d };
+    Assert.True(double.IsNegativeInfinity(source.Product()));
+  }
+
+  [Fact]
+  public void SolitaryNullableDouble()
+  {
+    double?[] source = { 20.51 };
+    Assert.Equal(source.First(), source.Product());
+  }
+
+  [Fact]
+  public void NullableDoubleAllNull()
+  {
+    Assert.Equal(null, System.Linq.Enumerable.Repeat(default(double?), 4).Product());
+  }
+
+  [Fact]
+  public void NullableDoubleToNegativeInfinity()
+  {
+    double?[] source = { -double.MaxValue, 2d };
+    Assert.True(double.IsNegativeInfinity(source.Product().Value));
+  }
+
+  [Fact]
+  public void SolitaryDecimal()
+  {
+    decimal[] source = { 20.51m };
+    Assert.Equal(source.First(), source.Product());
+  }
+
+  [Fact]
+  public void DecimalNegativeOverflow()
+  {
+    decimal[] source = { -decimal.MaxValue, 2m };
+    Assert.Throws<OverflowException>(() => source.Product());
+  }
+
+  [Fact]
+  public void SolitaryNullableDecimal()
+  {
+    decimal?[] source = { 20.51m };
+    Assert.Equal(source.First(), source.Product());
+  }
+
+  [Fact]
+  public void NullableDecimalAllNull()
+  {
+    Assert.Equal(null, System.Linq.Enumerable.Repeat(default(long?), 3).Product());
+  }
+
+  [Fact]
+  public void NullableDecimalNegativeOverflow()
+  {
+    decimal?[] source = { -decimal.MaxValue, 2m };
+    Assert.Throws<OverflowException>(() => source.Product());
+  }
+
+  [Fact]
+  public void SolitarySingle()
+  {
+    float[] source = { 20.51f };
+    Assert.Equal(source.First(), source.Product());
+  }
+
+  [Fact]
+  public void SingleToNegativeInfinity()
+  {
+    float[] source = { -float.MaxValue, 2f };
+    Assert.True(float.IsNegativeInfinity(source.Product()));
+  }
 }

--- a/tests/Ardalis.Extensions.UnitTests/Enumerable/ProductTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Enumerable/ProductTests.cs
@@ -1,0 +1,331 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ardalis.Extensions.Enumerable;
+using Xunit;
+
+namespace Ardalis.Extensions.UnitTests.Enumerables;
+
+public class ProducTests
+{
+  #region SourceIsNull - ArgumentNullExceptionThrown
+
+  [Fact]
+  public void ProductOfInt_SourceIsNull_ArgumentNullExceptionThrown()
+  {
+    IEnumerable<int> sourceInt = null;
+    Assert.Throws<ArgumentNullException>(() => sourceInt.Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableInt_SourceIsNull_ArgumentNullExceptionThrown()
+  {
+    IEnumerable<int?> sourceNullableInt = null;
+    Assert.Throws<ArgumentNullException>(() => sourceNullableInt.Product());
+  }
+
+  [Fact]
+  public void ProductOfLong_SourceIsNull_ArgumentNullExceptionThrown()
+  {
+    IEnumerable<long> sourceLong = null;
+    Assert.Throws<ArgumentNullException>(() => sourceLong.Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableLong_SourceIsNull_ArgumentNullExceptionThrown()
+  {
+    IEnumerable<long?> sourceNullableLong = null;
+    Assert.Throws<ArgumentNullException>(() => sourceNullableLong.Product());
+  }
+
+  [Fact]
+  public void ProductOfFloat_SourceIsNull_ArgumentNullExceptionThrown()
+  {
+    IEnumerable<float> sourceFloat = null;
+    Assert.Throws<ArgumentNullException>(() => sourceFloat.Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableFloat_SourceIsNull_ArgumentNullExceptionThrown()
+  {
+    IEnumerable<float?> sourceNullableFloat = null;
+    Assert.Throws<ArgumentNullException>(() => sourceNullableFloat.Product());
+  }
+
+  [Fact]
+  public void ProductOfDouble_SourceIsNull_ArgumentNullExceptionThrown()
+  {
+    IEnumerable<double> sourceDouble = null;
+    Assert.Throws<ArgumentNullException>(() => sourceDouble.Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableDouble_SourceIsNull_ArgumentNullExceptionThrown()
+  {
+    IEnumerable<double?> sourceNullableDouble = null;
+    Assert.Throws<ArgumentNullException>(() => sourceNullableDouble.Product());
+  }
+
+  [Fact]
+  public void ProductOfDecimal_SourceIsNull_ArgumentNullExceptionThrown()
+  {
+    IEnumerable<decimal> sourceDecimal = null;
+    Assert.Throws<ArgumentNullException>(() => sourceDecimal.Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableDecimal_SourceIsNull_ArgumentNullExceptionThrown()
+  {
+    IEnumerable<decimal?> sourceNullableDecimal = null;
+    Assert.Throws<ArgumentNullException>(() => sourceNullableDecimal.Product());
+  }
+
+  #endregion
+
+  #region SourceIsEmptyCollection - OneReturned
+
+  [Fact]
+  public void ProductOfInt_SourceIsEmptyCollection_OneReturned()
+  {
+    IEnumerable<int> sourceInt = System.Linq.Enumerable.Empty<int>();
+    Assert.Equal(1, sourceInt.Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableInt_SourceIsEmptyCollection_OneReturned()
+  {
+    IEnumerable<int?> sourceNullableInt = System.Linq.Enumerable.Empty<int?>();
+    Assert.Equal(1, sourceNullableInt.Product());
+  }
+
+  [Fact]
+  public void ProductOfLong_SourceIsEmptyCollection_OneReturned()
+  {
+    IEnumerable<long> sourceLong = System.Linq.Enumerable.Empty<long>();
+    Assert.Equal(1L, sourceLong.Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableLong_SourceIsEmptyCollection_OneReturned()
+  {
+    IEnumerable<long?> sourceNullableLong = System.Linq.Enumerable.Empty<long?>();
+    Assert.Equal(1L, sourceNullableLong.Product());
+  }
+
+  [Fact]
+  public void ProductOfFloat_SourceIsEmptyCollection_OneReturned()
+  {
+    IEnumerable<float> sourceFloat = System.Linq.Enumerable.Empty<float>();
+    Assert.Equal(1f, sourceFloat.Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableFloat_SourceIsEmptyCollection_OneReturned()
+  {
+    IEnumerable<float?> sourceNullableFloat = System.Linq.Enumerable.Empty<float?>();
+    Assert.Equal(1f, sourceNullableFloat.Product());
+  }
+
+  [Fact]
+  public void ProductOfDouble_SourceIsEmptyCollection_OneReturned()
+  {
+    IEnumerable<double> sourceDouble = System.Linq.Enumerable.Empty<double>();
+    Assert.Equal(1d, sourceDouble.Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableDouble_SourceIsEmptyCollection_OneReturned()
+  {
+    IEnumerable<double?> sourceNullableDouble = System.Linq.Enumerable.Empty<double?>();
+    Assert.Equal(1d, sourceNullableDouble.Product());
+  }
+
+  [Fact]
+  public void ProductOfDecimal_SourceIsEmptyCollection_OneReturned()
+  {
+    IEnumerable<decimal> sourceDecimal = System.Linq.Enumerable.Empty<decimal>();
+    Assert.Equal(1m, sourceDecimal.Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableDecimal_SourceIsEmptyCollection_OneReturned()
+  {
+    IEnumerable<decimal?> sourceNullableDecimal = System.Linq.Enumerable.Empty<decimal?>();
+    Assert.Equal(1m, sourceNullableDecimal.Product());
+  }
+
+  #endregion
+
+  #region SourceIsNotEmpty - ProperProductReturned
+
+  [Fact]
+  public void ProductOfInt_SourceIsNotEmpty_ProperProductReturned()
+  {
+    IEnumerable<int> sourceInt = new int[] { 0, 1, -2, 3, -4 };
+    Assert.Equal(0, sourceInt.Product());
+    Assert.Equal(24, sourceInt.Skip(1).Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableOfInt_SourceIsNotEmpty_ProperProductReturned()
+  {
+    IEnumerable<int?> sourceNullableInt = new int?[] { 0, 1, -2, 3, -4 };
+    Assert.Equal(0, sourceNullableInt.Product());
+    Assert.Equal(24, sourceNullableInt.Skip(1).Product());
+
+    sourceNullableInt = new int?[] { 1, -2, null, 3, -4, null };
+    Assert.Equal(null, sourceNullableInt.Product());
+  }
+
+  [Fact]
+  public void ProductOfLong_SourceIsNotEmpty_ProperProductReturned()
+  {
+    IEnumerable<long> sourceLong = new long[] { 0L, 1L, -2L, 3L, -4L };
+    Assert.Equal(0L, sourceLong.Product());
+    Assert.Equal(24L, sourceLong.Skip(1).Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableOfLong_SourceIsNotEmpty_ProperProductReturned()
+  {
+    IEnumerable<long?> sourceNullableLong = new long?[] { 0L, 1L, -2L, 3L, -4L };
+    Assert.Equal(0L, sourceNullableLong.Product());
+    Assert.Equal(24L, sourceNullableLong.Skip(1).Product());
+
+    sourceNullableLong = new long?[] { 1L, -2L, null, 3L, -4L, null };
+    Assert.Equal(null, sourceNullableLong.Product());
+  }
+
+  [Fact]
+  public void ProductOfFloat_SourceIsNotEmpty_ProperProductReturned()
+  {
+    IEnumerable<float> sourceFloat = new float[] { 0f, 1f, -2.5f, 3f, -4.5f };
+    Assert.Equal(0f, sourceFloat.Product());
+    Assert.Equal(33.75f, sourceFloat.Skip(1).Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableOfFloat_SourceIsNotEmpty_ProperProductReturned()
+  {
+    IEnumerable<float?> sourceNullableFloat = new float?[] { 0f, 1f, -2.5f, 3f, -4.5f };
+    Assert.Equal(0f, sourceNullableFloat.Product());
+    Assert.Equal(33.75f, sourceNullableFloat.Skip(1).Product());
+
+    sourceNullableFloat = new float?[] { 1f, -2.5f, null, 3f, -4.5f, null };
+    Assert.Equal(null, sourceNullableFloat.Product());
+  }
+
+  [Fact]
+  public void ProductOfDouble_SourceIsNotEmpty_ProperProductReturned()
+  {
+    IEnumerable<double> sourceDouble = new double[] { 0d, 1d, -2.5d, 3d, -4.5d };
+    Assert.Equal(0d, sourceDouble.Product());
+    Assert.Equal(33.75d, sourceDouble.Skip(1).Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableOfDouble_SourceIsNotEmpty_ProperProductReturned()
+  {
+    IEnumerable<double?> sourceNullableDouble = new double?[] { 0d, 1d, -2.5d, 3d, -4.5d };
+    Assert.Equal(0d, sourceNullableDouble.Product());
+    Assert.Equal(33.75d, sourceNullableDouble.Skip(1).Product());
+
+    sourceNullableDouble = new double?[] { 1, -2, null, 3, -4, null };
+    Assert.Equal(null, sourceNullableDouble.Product());
+  }
+
+  [Fact]
+  public void ProductOfDecimal_SourceIsNotEmpty_ProperProductReturned()
+  {
+    IEnumerable<decimal> sourceDecimal = new decimal[] { 0m, 1m, -2.5m, 3m, -4.5m };
+    Assert.Equal(0m, sourceDecimal.Product());
+    Assert.Equal(33.75m, sourceDecimal.Skip(1).Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableOfDecimal_SourceIsNotEmpty_ProperProductReturned()
+  {
+    IEnumerable<decimal?> sourceNullableDecimal = new decimal?[] { 0m, 1m, -2.5m, 3m, -4.5m };
+    Assert.Equal(0m, sourceNullableDecimal.Product());
+    Assert.Equal(33.75m, sourceNullableDecimal.Skip(1).Product());
+
+    sourceNullableDecimal = new decimal?[] { 1, -2, null, 3, -4, null };
+    Assert.Equal(null, sourceNullableDecimal.Product());
+  }
+
+  #endregion
+
+  #region SourceMultipliesToOverflow - OverflowExceptionThrown or Infinity returned
+
+  [Fact]
+  public void ProductOfInt_SourceMultipliesToOverflow_OverflowExceptionThrown()
+  {
+    IEnumerable<int> sourceInt = new int[] { int.MaxValue, 2 };
+    Assert.Throws<OverflowException>(() => sourceInt.Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableOfInt_SourceMultipliesToOverflow_OverflowExceptionThrown()
+  {
+    IEnumerable<int?> sourceNullableInt = new int?[] { int.MaxValue, 2 };
+    Assert.Throws<OverflowException>(() => sourceNullableInt.Product());
+  }
+
+  [Fact]
+  public void ProductOfLong_SourceMultipliesToOverflow_OverflowExceptionThrown()
+  {
+    IEnumerable<long> sourceLong = new long[] { long.MaxValue, 2L };
+    Assert.Throws<OverflowException>(() => sourceLong.Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableOfLong_SourceMultipliesToOverflow_OverflowExceptionThrown()
+  {
+    IEnumerable<long?> sourceNullableLong = new long?[] { long.MaxValue, 2L };
+    Assert.Throws<OverflowException>(() => sourceNullableLong.Product());
+  }
+
+  [Fact]
+  public void ProductOfFloat_SourceMultipliesToOverflow_InfinityReturned()
+  {
+    IEnumerable<float> sourceFloat = new float[] { float.MaxValue, float.MaxValue };
+    Assert.True(float.IsPositiveInfinity(sourceFloat.Product()));
+  }
+
+  [Fact]
+  public void ProductOfNullableOfFloat_SourceMultipliesToOverflow_InfinityReturned()
+  {
+    IEnumerable<float?> sourceNullableFloat = new float?[] { float.MaxValue, float.MaxValue };
+    Assert.True(float.IsPositiveInfinity(sourceNullableFloat.Product().Value));
+  }
+
+  [Fact]
+  public void ProductOfDouble_SourceMultipliesToOverflow_InfinityReturned()
+  {
+    IEnumerable<double> sourceDouble = new double[] { double.MaxValue, double.MaxValue };
+    Assert.True(double.IsPositiveInfinity(sourceDouble.Product()));
+  }
+
+  [Fact]
+  public void ProductOfNullableOfDouble_SourceMultipliesToOverflow_InfinityReturned()
+  {
+    IEnumerable<double?> sourceNullableDouble = new double?[] { double.MaxValue, double.MaxValue };
+    Assert.True(double.IsPositiveInfinity(sourceNullableDouble.Product().Value));
+  }
+
+  [Fact]
+  public void ProductOfDecimal_SourceMultipliesToOverflow_OverflowExceptionThrown()
+  {
+    IEnumerable<decimal> sourceDecimal = new decimal[] { decimal.MaxValue, 2m };
+    Assert.Throws<OverflowException>(() => sourceDecimal.Product());
+  }
+
+  [Fact]
+  public void ProductOfNullableOfDecimal_SourceMultipliesToOverflow_OverflowExceptionThrown()
+  {
+    IEnumerable<decimal?> sourceNullableDecimal = new decimal?[] { decimal.MaxValue, 2m };
+    Assert.Throws<OverflowException>(() => sourceNullableDecimal.Product());
+  }
+
+  #endregion
+}


### PR DESCRIPTION
This extension method is similar to the `Sum` method, except that it multiplies the items in the `IEnumerable` instead of adding them. I've implemented it for every type of number (int, long, float, double, decimal) and have tested it extensively.

Benchmarks show that the chosen implementation offers significant performance over other common alternatives.

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.22000
12th Gen Intel Core i9-12900K, 1 CPU, 24 logical and 16 physical cores
.NET Core SDK=6.0.400
  [Host]     : .NET Core 6.0.8 (CoreCLR 6.0.822.36306, CoreFX 6.0.822.36306), X64 RyuJIT
  DefaultJob : .NET Core 6.0.8 (CoreCLR 6.0.822.36306, CoreFX 6.0.822.36306), X64 RyuJIT


```
|           Method |    N |         Mean |      Error |     StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |----- |-------------:|-----------:|-----------:|------:|-------:|------:|------:|----------:|
| **ProductAggregate** |    **1** |    **12.285 ns** |  **0.1644 ns** |  **0.1538 ns** |  **1.00** | **0.0020** |     **-** |     **-** |      **32 B** |
|   ProductForEach |    1 |    10.475 ns |  0.0928 ns |  0.0868 ns |  0.85 | 0.0020 |     - |     - |      32 B |
|          Product |    1 |     3.064 ns |  0.0372 ns |  0.0348 ns |  0.25 |      - |     - |     - |         - |
|                  |      |              |            |            |       |        |       |       |           |
| **ProductAggregate** |   **10** |    **41.003 ns** |  **0.2373 ns** |  **0.1981 ns** |  **1.00** | **0.0020** |     **-** |     **-** |      **32 B** |
|   ProductForEach |   10 |    33.809 ns |  0.4208 ns |  0.3514 ns |  0.82 | 0.0020 |     - |     - |      32 B |
|          Product |   10 |     5.888 ns |  0.0842 ns |  0.0787 ns |  0.14 |      - |     - |     - |         - |
|                  |      |              |            |            |       |        |       |       |           |
| **ProductAggregate** |  **100** |   **364.044 ns** |  **5.4466 ns** |  **4.5481 ns** |  **1.00** | **0.0019** |     **-** |     **-** |      **32 B** |
|   ProductForEach |  100 |   299.335 ns |  2.4880 ns |  2.3272 ns |  0.82 | 0.0019 |     - |     - |      32 B |
|          Product |  100 |    47.687 ns |  0.3365 ns |  0.2983 ns |  0.13 |      - |     - |     - |         - |
|                  |      |              |            |            |       |        |       |       |           |
| **ProductAggregate** | **1000** | **3,242.624 ns** | **22.2032 ns** | **17.3348 ns** |  **1.00** |      **-** |     **-** |     **-** |      **32 B** |
|   ProductForEach | 1000 | 2,874.950 ns | 24.9146 ns | 22.0861 ns |  0.89 |      - |     - |     - |      32 B |
|          Product | 1000 |   750.601 ns |  7.5546 ns |  7.0666 ns |  0.23 |      - |     - |     - |         - |
