### PR TITLE
For each with index

### DIFF
--- a/src/Ardalis.Extensions/Enumerable/ForEach.cs
+++ b/src/Ardalis.Extensions/Enumerable/ForEach.cs
@@ -7,19 +7,40 @@ namespace Ardalis.Extensions.Enumerable;
 public static partial class EnumerableExtensions
 {
   /// <summary>
-  /// Iterates over an enumerable and executes an Action on each item.
+  /// Iterates over an enumerable and executes an Action on each element.
   /// </summary>
-  /// <typeparam name="T">The generic type of the enumerable</typeparam>
-  /// <param name="input">An IEnumerable<typeparamref name="T"/> input</param>
-  /// <param name="action">The action to invoke on each item in the enumerable</param>
-  public static void ForEach<T>(this IEnumerable<T> input, Action<T> action)
+  /// <typeparam name="TSource">The type of the elements of source.</typeparam>
+  /// <param name="source">A sequence of values to invoke an action on.</param>
+  /// <param name="action">An Action to invoke on each source element.</param>
+  public static void ForEach<T>(this IEnumerable<T> source, Action<T> action)
   {
-    Guard.Against.Null(input, nameof(input));
+    Guard.Against.Null(source, nameof(source));
     Guard.Against.Null(action, nameof(action));
 
-    foreach (var item in input)
+    foreach (var item in source)
     {
       action(item);
+    }
+  }
+
+  /// <summary>
+  /// Iterates over an enumerable and executes an Action on each element.
+  /// </summary>
+  /// <typeparam name="TSource">The type of the elements of source.</typeparam>
+  /// <param name="source">A sequence of values to invoke an action on.</param>
+  /// <param name="callback">
+  ///  An Action to invoke on each source element.
+  ///  The second parameter of the Action represents the index of the source element.
+  /// </param>
+  public static void ForEach<TSource>(this IEnumerable<TSource> source, Action<TSource, int> action)
+  {
+    Guard.Against.Null(source, nameof(source));
+    Guard.Against.Null(action, nameof(action));
+
+    int index = 0;
+    foreach (var item in source)
+    {
+      action(item, index++);
     }
   }
 }

--- a/tests/Ardalis.Extensions.UnitTests/Enumerable/ForEachTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Enumerable/ForEachTests.cs
@@ -40,4 +40,17 @@ public class ForEachTests
 
     Assert.Equal(6, sum);
   }
+
+  [Fact]
+  public void ForEachPropertyUsingIndex()
+  {
+    var source = new List<string> { "a", "b", null, "d" };
+
+    var expected = new List<string> { "a0", "b1", "2", "d3" };
+    var actual = new List<string>();
+
+    source.ForEach((e, i) => actual.Add($"{e}{i}"));
+
+    Assert.Equal(expected, actual);
+  }
 }


### PR DESCRIPTION
 - Made the method doc use similar description and variable names as the .NET official documentation.
 - Add ForEach overload that passes the index of the source element as the second param to the Action callback.