### PR TITLE
WhenAll() for tuples

### DIFF
--- a/src/Ardalis.Extensions/Tasks/WhenAll.cs
+++ b/src/Ardalis.Extensions/Tasks/WhenAll.cs
@@ -6,14 +6,41 @@ namespace Ardalis.Extensions.Tasks;
 public static partial class TasksExtensions
 {
 
+  /// <summary>
+  /// Creates a task that will complete when all of the supplied tasks have completed.
+  /// </summary>
+  /// <param name="tasks">The tasks to wait on for completion.</param>
+  /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
+  /// <remarks>
+  /// <para>
+  /// If any of the supplied tasks completes in a faulted state, the returned task will also complete in a Faulted state,
+  /// where its exceptions will contain the aggregation of the set of unwrapped exceptions from each of the supplied tasks.
+  /// </para>
+  /// <para>
+  /// If none of the supplied tasks faulted but at least one of them was canceled, the returned task will end in the Canceled state.
+  /// </para>
+  /// <para>
+  /// If none of the tasks faulted and none of the tasks were canceled, the resulting task will end in the RanToCompletion state.
+  /// </para>
+  /// </remarks>
+  /// <exception cref="System.ArgumentException">
+  /// The <paramref name="tasks"/> tuple contained a null task.
+  /// </exception>
   public static async Task<(T1, T2)> WhenAll<T1, T2>(this (Task<T1>, Task<T2>) tasks)
   {
     var task = Task.WhenAll(tasks.Item1, tasks.Item2);
-    try 
+    try
     {
       await task;
-    } catch (Exception) {
-      throw task.Exception;
+    }
+    catch (Exception e)
+    {
+      if (task.Exception != null)
+      {
+        throw task.Exception;
+      }
+
+      throw e;
     }
 
     return (tasks.Item1.Result, tasks.Item2.Result);
@@ -22,30 +49,40 @@ public static partial class TasksExtensions
   public static async Task<(T1, T2, T3)> WhenAll<T1, T2, T3>(this (Task<T1>, Task<T2>, Task<T3>) tasks)
   {
     var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3);
-    try 
+    try
     {
       await task;
     }
-    catch (Exception)
+    catch (Exception e)
     {
-      throw task.Exception;
+      if (task.Exception != null)
+      {
+        throw task.Exception;
+      }
+
+      throw e;
     }
-    
+
     return (tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result);
   }
 
   public static async Task<(T1, T2, T3, T4)> WhenAll<T1, T2, T3, T4>(this (Task<T1>, Task<T2>, Task<T3>, Task<T4>) tasks)
   {
     var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4);
-    try 
+    try
     {
       await task;
     }
-    catch (Exception)
+    catch (Exception e)
     {
-      throw task.Exception;
+      if (task.Exception != null)
+      {
+        throw task.Exception;
+      }
+
+      throw e;
     }
-    
+
     return (tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result);
   }
 
@@ -53,15 +90,20 @@ public static partial class TasksExtensions
     this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>) tasks)
   {
     var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5);
-    try 
+    try
     {
       await task;
     }
-    catch (Exception)
+    catch (Exception e)
     {
-      throw task.Exception;
+      if (task.Exception != null)
+      {
+        throw task.Exception;
+      }
+
+      throw e;
     }
-    
+
     return (tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result);
   }
 
@@ -69,17 +111,22 @@ public static partial class TasksExtensions
     this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>) tasks)
   {
     var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6);
-    try 
+    try
     {
       await task;
     }
-    catch (Exception)
+    catch (Exception e)
     {
-      throw task.Exception;
+      if (task.Exception != null)
+      {
+        throw task.Exception;
+      }
+
+      throw e;
     }
-    
+
     return (
-      tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result, 
+      tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result,
       tasks.Item6.Result);
   }
 
@@ -88,17 +135,22 @@ public static partial class TasksExtensions
   {
     var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6,
       tasks.Item7);
-    try 
+    try
     {
       await task;
     }
-    catch (Exception)
+    catch (Exception e)
     {
-      throw task.Exception;
+      if (task.Exception != null)
+      {
+        throw task.Exception;
+      }
+
+      throw e;
     }
-    
+
     return (
-      tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result, 
+      tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result,
       tasks.Item6.Result, tasks.Item7.Result);
   }
 
@@ -107,17 +159,22 @@ public static partial class TasksExtensions
   {
     var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6,
       tasks.Item7, tasks.Item8);
-    try 
+    try
     {
       await task;
     }
-    catch (Exception)
+    catch (Exception e)
     {
-      throw task.Exception;
+      if (task.Exception != null)
+      {
+        throw task.Exception;
+      }
+
+      throw e;
     }
-    
+
     return (
-      tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result, 
+      tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result,
       tasks.Item6.Result, tasks.Item7.Result, tasks.Item8.Result);
   }
 
@@ -126,17 +183,22 @@ public static partial class TasksExtensions
   {
     var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6,
       tasks.Item7, tasks.Item8, tasks.Item9);
-    try 
+    try
     {
       await task;
     }
-    catch (Exception)
+    catch (Exception e)
     {
-      throw task.Exception;
+      if (task.Exception != null)
+      {
+        throw task.Exception;
+      }
+
+      throw e;
     }
-    
+
     return (
-      tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result, 
+      tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result,
       tasks.Item6.Result, tasks.Item7.Result, tasks.Item8.Result, tasks.Item9.Result);
   }
 
@@ -145,17 +207,22 @@ public static partial class TasksExtensions
   {
     var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6,
       tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10);
-    try 
+    try
     {
       await task;
     }
-    catch (Exception)
+    catch (Exception e)
     {
-      throw task.Exception;
+      if (task.Exception != null)
+      {
+        throw task.Exception;
+      }
+
+      throw e;
     }
-    
+
     return (
-      tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result, 
+      tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result,
       tasks.Item6.Result, tasks.Item7.Result, tasks.Item8.Result, tasks.Item9.Result, tasks.Item10.Result);
   }
 }

--- a/src/Ardalis.Extensions/Tasks/WhenAll.cs
+++ b/src/Ardalis.Extensions/Tasks/WhenAll.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Ardalis.Extensions.Tasks;
+
+public static partial class TasksExtensions
+{
+  public static Task<Tuple<T1>> WhenAll<T1>(this Tuple<Task<T1>> tasks)
+  {
+    return Task.WhenAll(tasks.Item1).ContinueWith(t => Tuple.Create(t.Result[0]));
+  }
+}

--- a/src/Ardalis.Extensions/Tasks/WhenAll.cs
+++ b/src/Ardalis.Extensions/Tasks/WhenAll.cs
@@ -36,7 +36,7 @@ public static partial class TasksExtensions
 
   public static async Task<(T1, T2, T3, T4)> WhenAll<T1, T2, T3, T4>(this (Task<T1>, Task<T2>, Task<T3>, Task<T4>) tasks)
   {
-    var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3);
+    var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4);
     try 
     {
       await task;
@@ -52,7 +52,7 @@ public static partial class TasksExtensions
   public static async Task<(T1, T2, T3, T4, T5)> WhenAll<T1, T2, T3, T4, T5>(
     this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>) tasks)
   {
-    var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3);
+    var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5);
     try 
     {
       await task;
@@ -68,7 +68,7 @@ public static partial class TasksExtensions
   public static async Task<(T1, T2, T3, T4, T5, T6)> WhenAll<T1, T2, T3, T4, T5, T6>(
     this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>) tasks)
   {
-    var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3);
+    var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6);
     try 
     {
       await task;
@@ -86,7 +86,8 @@ public static partial class TasksExtensions
   public static async Task<(T1, T2, T3, T4, T5, T6, T7)> WhenAll<T1, T2, T3, T4, T5, T6, T7>(
     this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>, Task<T7>) tasks)
   {
-    var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3);
+    var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6,
+      tasks.Item7);
     try 
     {
       await task;
@@ -99,5 +100,24 @@ public static partial class TasksExtensions
     return (
       tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result, 
       tasks.Item6.Result, tasks.Item7.Result);
+  }
+
+  public static async Task<(T1, T2, T3, T4, T5, T6, T7, T8)> WhenAll<T1, T2, T3, T4, T5, T6, T7, T8>(
+    this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>, Task<T7>, Task<T8>) tasks)
+  {
+    var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6,
+      tasks.Item7, tasks.Item8);
+    try 
+    {
+      await task;
+    }
+    catch (Exception)
+    {
+      throw task.Exception;
+    }
+    
+    return (
+      tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result, 
+      tasks.Item6.Result, tasks.Item7.Result, tasks.Item8.Result);
   }
 }

--- a/src/Ardalis.Extensions/Tasks/WhenAll.cs
+++ b/src/Ardalis.Extensions/Tasks/WhenAll.cs
@@ -48,4 +48,19 @@ public static partial class TasksExtensions
     
     return (tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result);
   }
+
+  public static async Task<(T1, T2, T3, T4, T5)> WhenAll<T1, T2, T3, T4, T5>(this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>) tasks)
+  {
+    var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3);
+    try 
+    {
+      await task;
+    }
+    catch (Exception)
+    {
+      throw task.Exception;
+    }
+    
+    return (tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result);
+  }
 }

--- a/src/Ardalis.Extensions/Tasks/WhenAll.cs
+++ b/src/Ardalis.Extensions/Tasks/WhenAll.cs
@@ -14,7 +14,15 @@ public static partial class TasksExtensions
 
   public static async Task<(T1, T2, T3)> WhenAll<T1, T2, T3>(this (Task<T1>, Task<T2>, Task<T3>) tasks)
   {
-    await Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3);
+    var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3);
+    try {
+      await task;
+    }
+    catch (Exception)
+    {
+      throw task.Exception;
+    }
+    
     return (tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result);
   }
 }

--- a/src/Ardalis.Extensions/Tasks/WhenAll.cs
+++ b/src/Ardalis.Extensions/Tasks/WhenAll.cs
@@ -46,6 +46,26 @@ public static partial class TasksExtensions
     return (tasks.Item1.Result, tasks.Item2.Result);
   }
 
+  /// <summary>
+  /// Creates a task that will complete when all of the supplied tasks have completed.
+  /// </summary>
+  /// <param name="tasks">The tasks to wait on for completion.</param>
+  /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
+  /// <remarks>
+  /// <para>
+  /// If any of the supplied tasks completes in a faulted state, the returned task will also complete in a Faulted state,
+  /// where its exceptions will contain the aggregation of the set of unwrapped exceptions from each of the supplied tasks.
+  /// </para>
+  /// <para>
+  /// If none of the supplied tasks faulted but at least one of them was canceled, the returned task will end in the Canceled state.
+  /// </para>
+  /// <para>
+  /// If none of the tasks faulted and none of the tasks were canceled, the resulting task will end in the RanToCompletion state.
+  /// </para>
+  /// </remarks>
+  /// <exception cref="System.ArgumentException">
+  /// The <paramref name="tasks"/> tuple contained a null task.
+  /// </exception>
   public static async Task<(T1, T2, T3)> WhenAll<T1, T2, T3>(this (Task<T1>, Task<T2>, Task<T3>) tasks)
   {
     var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3);
@@ -66,6 +86,26 @@ public static partial class TasksExtensions
     return (tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result);
   }
 
+  /// <summary>
+  /// Creates a task that will complete when all of the supplied tasks have completed.
+  /// </summary>
+  /// <param name="tasks">The tasks to wait on for completion.</param>
+  /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
+  /// <remarks>
+  /// <para>
+  /// If any of the supplied tasks completes in a faulted state, the returned task will also complete in a Faulted state,
+  /// where its exceptions will contain the aggregation of the set of unwrapped exceptions from each of the supplied tasks.
+  /// </para>
+  /// <para>
+  /// If none of the supplied tasks faulted but at least one of them was canceled, the returned task will end in the Canceled state.
+  /// </para>
+  /// <para>
+  /// If none of the tasks faulted and none of the tasks were canceled, the resulting task will end in the RanToCompletion state.
+  /// </para>
+  /// </remarks>
+  /// <exception cref="System.ArgumentException">
+  /// The <paramref name="tasks"/> tuple contained a null task.
+  /// </exception>
   public static async Task<(T1, T2, T3, T4)> WhenAll<T1, T2, T3, T4>(this (Task<T1>, Task<T2>, Task<T3>, Task<T4>) tasks)
   {
     var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4);
@@ -86,6 +126,26 @@ public static partial class TasksExtensions
     return (tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result);
   }
 
+  /// <summary>
+  /// Creates a task that will complete when all of the supplied tasks have completed.
+  /// </summary>
+  /// <param name="tasks">The tasks to wait on for completion.</param>
+  /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
+  /// <remarks>
+  /// <para>
+  /// If any of the supplied tasks completes in a faulted state, the returned task will also complete in a Faulted state,
+  /// where its exceptions will contain the aggregation of the set of unwrapped exceptions from each of the supplied tasks.
+  /// </para>
+  /// <para>
+  /// If none of the supplied tasks faulted but at least one of them was canceled, the returned task will end in the Canceled state.
+  /// </para>
+  /// <para>
+  /// If none of the tasks faulted and none of the tasks were canceled, the resulting task will end in the RanToCompletion state.
+  /// </para>
+  /// </remarks>
+  /// <exception cref="System.ArgumentException">
+  /// The <paramref name="tasks"/> tuple contained a null task.
+  /// </exception>
   public static async Task<(T1, T2, T3, T4, T5)> WhenAll<T1, T2, T3, T4, T5>(
     this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>) tasks)
   {
@@ -107,6 +167,26 @@ public static partial class TasksExtensions
     return (tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result);
   }
 
+  /// <summary>
+  /// Creates a task that will complete when all of the supplied tasks have completed.
+  /// </summary>
+  /// <param name="tasks">The tasks to wait on for completion.</param>
+  /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
+  /// <remarks>
+  /// <para>
+  /// If any of the supplied tasks completes in a faulted state, the returned task will also complete in a Faulted state,
+  /// where its exceptions will contain the aggregation of the set of unwrapped exceptions from each of the supplied tasks.
+  /// </para>
+  /// <para>
+  /// If none of the supplied tasks faulted but at least one of them was canceled, the returned task will end in the Canceled state.
+  /// </para>
+  /// <para>
+  /// If none of the tasks faulted and none of the tasks were canceled, the resulting task will end in the RanToCompletion state.
+  /// </para>
+  /// </remarks>
+  /// <exception cref="System.ArgumentException">
+  /// The <paramref name="tasks"/> tuple contained a null task.
+  /// </exception>
   public static async Task<(T1, T2, T3, T4, T5, T6)> WhenAll<T1, T2, T3, T4, T5, T6>(
     this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>) tasks)
   {
@@ -130,6 +210,26 @@ public static partial class TasksExtensions
       tasks.Item6.Result);
   }
 
+  /// <summary>
+  /// Creates a task that will complete when all of the supplied tasks have completed.
+  /// </summary>
+  /// <param name="tasks">The tasks to wait on for completion.</param>
+  /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
+  /// <remarks>
+  /// <para>
+  /// If any of the supplied tasks completes in a faulted state, the returned task will also complete in a Faulted state,
+  /// where its exceptions will contain the aggregation of the set of unwrapped exceptions from each of the supplied tasks.
+  /// </para>
+  /// <para>
+  /// If none of the supplied tasks faulted but at least one of them was canceled, the returned task will end in the Canceled state.
+  /// </para>
+  /// <para>
+  /// If none of the tasks faulted and none of the tasks were canceled, the resulting task will end in the RanToCompletion state.
+  /// </para>
+  /// </remarks>
+  /// <exception cref="System.ArgumentException">
+  /// The <paramref name="tasks"/> tuple contained a null task.
+  /// </exception>
   public static async Task<(T1, T2, T3, T4, T5, T6, T7)> WhenAll<T1, T2, T3, T4, T5, T6, T7>(
     this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>, Task<T7>) tasks)
   {
@@ -154,6 +254,26 @@ public static partial class TasksExtensions
       tasks.Item6.Result, tasks.Item7.Result);
   }
 
+  /// <summary>
+  /// Creates a task that will complete when all of the supplied tasks have completed.
+  /// </summary>
+  /// <param name="tasks">The tasks to wait on for completion.</param>
+  /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
+  /// <remarks>
+  /// <para>
+  /// If any of the supplied tasks completes in a faulted state, the returned task will also complete in a Faulted state,
+  /// where its exceptions will contain the aggregation of the set of unwrapped exceptions from each of the supplied tasks.
+  /// </para>
+  /// <para>
+  /// If none of the supplied tasks faulted but at least one of them was canceled, the returned task will end in the Canceled state.
+  /// </para>
+  /// <para>
+  /// If none of the tasks faulted and none of the tasks were canceled, the resulting task will end in the RanToCompletion state.
+  /// </para>
+  /// </remarks>
+  /// <exception cref="System.ArgumentException">
+  /// The <paramref name="tasks"/> tuple contained a null task.
+  /// </exception>
   public static async Task<(T1, T2, T3, T4, T5, T6, T7, T8)> WhenAll<T1, T2, T3, T4, T5, T6, T7, T8>(
     this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>, Task<T7>, Task<T8>) tasks)
   {
@@ -178,6 +298,26 @@ public static partial class TasksExtensions
       tasks.Item6.Result, tasks.Item7.Result, tasks.Item8.Result);
   }
 
+  /// <summary>
+  /// Creates a task that will complete when all of the supplied tasks have completed.
+  /// </summary>
+  /// <param name="tasks">The tasks to wait on for completion.</param>
+  /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
+  /// <remarks>
+  /// <para>
+  /// If any of the supplied tasks completes in a faulted state, the returned task will also complete in a Faulted state,
+  /// where its exceptions will contain the aggregation of the set of unwrapped exceptions from each of the supplied tasks.
+  /// </para>
+  /// <para>
+  /// If none of the supplied tasks faulted but at least one of them was canceled, the returned task will end in the Canceled state.
+  /// </para>
+  /// <para>
+  /// If none of the tasks faulted and none of the tasks were canceled, the resulting task will end in the RanToCompletion state.
+  /// </para>
+  /// </remarks>
+  /// <exception cref="System.ArgumentException">
+  /// The <paramref name="tasks"/> tuple contained a null task.
+  /// </exception>
   public static async Task<(T1, T2, T3, T4, T5, T6, T7, T8, T9)> WhenAll<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
     this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>, Task<T7>, Task<T8>, Task<T9>) tasks)
   {
@@ -202,6 +342,26 @@ public static partial class TasksExtensions
       tasks.Item6.Result, tasks.Item7.Result, tasks.Item8.Result, tasks.Item9.Result);
   }
 
+  /// <summary>
+  /// Creates a task that will complete when all of the supplied tasks have completed.
+  /// </summary>
+  /// <param name="tasks">The tasks to wait on for completion.</param>
+  /// <returns>A task that represents the completion of all of the supplied tasks.</returns>
+  /// <remarks>
+  /// <para>
+  /// If any of the supplied tasks completes in a faulted state, the returned task will also complete in a Faulted state,
+  /// where its exceptions will contain the aggregation of the set of unwrapped exceptions from each of the supplied tasks.
+  /// </para>
+  /// <para>
+  /// If none of the supplied tasks faulted but at least one of them was canceled, the returned task will end in the Canceled state.
+  /// </para>
+  /// <para>
+  /// If none of the tasks faulted and none of the tasks were canceled, the resulting task will end in the RanToCompletion state.
+  /// </para>
+  /// </remarks>
+  /// <exception cref="System.ArgumentException">
+  /// The <paramref name="tasks"/> tuple contained a null task.
+  /// </exception>
   public static async Task<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)> WhenAll<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
     this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>, Task<T7>, Task<T8>, Task<T9>, Task<T10>) tasks)
   {

--- a/src/Ardalis.Extensions/Tasks/WhenAll.cs
+++ b/src/Ardalis.Extensions/Tasks/WhenAll.cs
@@ -79,7 +79,25 @@ public static partial class TasksExtensions
     }
     
     return (
-      tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, 
-      tasks.Item4.Result, tasks.Item5.Result, tasks.Item6.Result);
+      tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result, 
+      tasks.Item6.Result);
+  }
+
+  public static async Task<(T1, T2, T3, T4, T5, T6, T7)> WhenAll<T1, T2, T3, T4, T5, T6, T7>(
+    this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>, Task<T7>) tasks)
+  {
+    var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3);
+    try 
+    {
+      await task;
+    }
+    catch (Exception)
+    {
+      throw task.Exception;
+    }
+    
+    return (
+      tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result, 
+      tasks.Item6.Result, tasks.Item7.Result);
   }
 }

--- a/src/Ardalis.Extensions/Tasks/WhenAll.cs
+++ b/src/Ardalis.Extensions/Tasks/WhenAll.cs
@@ -49,7 +49,8 @@ public static partial class TasksExtensions
     return (tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result);
   }
 
-  public static async Task<(T1, T2, T3, T4, T5)> WhenAll<T1, T2, T3, T4, T5>(this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>) tasks)
+  public static async Task<(T1, T2, T3, T4, T5)> WhenAll<T1, T2, T3, T4, T5>(
+    this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>) tasks)
   {
     var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3);
     try 
@@ -62,5 +63,23 @@ public static partial class TasksExtensions
     }
     
     return (tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result);
+  }
+
+  public static async Task<(T1, T2, T3, T4, T5, T6)> WhenAll<T1, T2, T3, T4, T5, T6>(
+    this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>) tasks)
+  {
+    var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3);
+    try 
+    {
+      await task;
+    }
+    catch (Exception)
+    {
+      throw task.Exception;
+    }
+    
+    return (
+      tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, 
+      tasks.Item4.Result, tasks.Item5.Result, tasks.Item6.Result);
   }
 }

--- a/src/Ardalis.Extensions/Tasks/WhenAll.cs
+++ b/src/Ardalis.Extensions/Tasks/WhenAll.cs
@@ -125,7 +125,7 @@ public static partial class TasksExtensions
     this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>, Task<T7>, Task<T8>, Task<T9>) tasks)
   {
     var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6,
-      tasks.Item7, tasks.Item8);
+      tasks.Item7, tasks.Item8, tasks.Item9);
     try 
     {
       await task;
@@ -138,5 +138,24 @@ public static partial class TasksExtensions
     return (
       tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result, 
       tasks.Item6.Result, tasks.Item7.Result, tasks.Item8.Result, tasks.Item9.Result);
+  }
+
+  public static async Task<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)> WhenAll<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+    this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>, Task<T7>, Task<T8>, Task<T9>, Task<T10>) tasks)
+  {
+    var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6,
+      tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10);
+    try 
+    {
+      await task;
+    }
+    catch (Exception)
+    {
+      throw task.Exception;
+    }
+    
+    return (
+      tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result, 
+      tasks.Item6.Result, tasks.Item7.Result, tasks.Item8.Result, tasks.Item9.Result, tasks.Item10.Result);
   }
 }

--- a/src/Ardalis.Extensions/Tasks/WhenAll.cs
+++ b/src/Ardalis.Extensions/Tasks/WhenAll.cs
@@ -5,8 +5,10 @@ namespace Ardalis.Extensions.Tasks;
 
 public static partial class TasksExtensions
 {
-  public static Task<Tuple<T1>> WhenAll<T1>(this Tuple<Task<T1>> tasks)
+
+  public static async Task<(T1, T2)> WhenAll<T1, T2>(this (Task<T1>, Task<T2>) tasks)
   {
-    return Task.WhenAll(tasks.Item1).ContinueWith(t => Tuple.Create(t.Result[0]));
+    await Task.WhenAll(tasks.Item1, tasks.Item2);
+    return (tasks.Item1.Result, tasks.Item2.Result);
   }
 }

--- a/src/Ardalis.Extensions/Tasks/WhenAll.cs
+++ b/src/Ardalis.Extensions/Tasks/WhenAll.cs
@@ -33,14 +33,14 @@ public static partial class TasksExtensions
     {
       await task;
     }
-    catch (Exception e)
+    catch (Exception)
     {
       if (task.Exception != null)
       {
         throw task.Exception;
       }
 
-      throw e;
+      throw;
     }
 
     return (tasks.Item1.Result, tasks.Item2.Result);
@@ -73,14 +73,14 @@ public static partial class TasksExtensions
     {
       await task;
     }
-    catch (Exception e)
+    catch (Exception)
     {
       if (task.Exception != null)
       {
         throw task.Exception;
       }
 
-      throw e;
+      throw;
     }
 
     return (tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result);
@@ -113,14 +113,14 @@ public static partial class TasksExtensions
     {
       await task;
     }
-    catch (Exception e)
+    catch (Exception)
     {
       if (task.Exception != null)
       {
         throw task.Exception;
       }
 
-      throw e;
+      throw;
     }
 
     return (tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result);
@@ -154,14 +154,14 @@ public static partial class TasksExtensions
     {
       await task;
     }
-    catch (Exception e)
+    catch (Exception)
     {
       if (task.Exception != null)
       {
         throw task.Exception;
       }
 
-      throw e;
+      throw;
     }
 
     return (tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result);
@@ -195,14 +195,14 @@ public static partial class TasksExtensions
     {
       await task;
     }
-    catch (Exception e)
+    catch (Exception)
     {
       if (task.Exception != null)
       {
         throw task.Exception;
       }
 
-      throw e;
+      throw;
     }
 
     return (
@@ -239,14 +239,14 @@ public static partial class TasksExtensions
     {
       await task;
     }
-    catch (Exception e)
+    catch (Exception)
     {
       if (task.Exception != null)
       {
         throw task.Exception;
       }
 
-      throw e;
+      throw;
     }
 
     return (
@@ -283,14 +283,14 @@ public static partial class TasksExtensions
     {
       await task;
     }
-    catch (Exception e)
+    catch (Exception)
     {
       if (task.Exception != null)
       {
         throw task.Exception;
       }
 
-      throw e;
+      throw;
     }
 
     return (
@@ -327,14 +327,14 @@ public static partial class TasksExtensions
     {
       await task;
     }
-    catch (Exception e)
+    catch (Exception)
     {
       if (task.Exception != null)
       {
         throw task.Exception;
       }
 
-      throw e;
+      throw;
     }
 
     return (
@@ -371,14 +371,14 @@ public static partial class TasksExtensions
     {
       await task;
     }
-    catch (Exception e)
+    catch (Exception)
     {
       if (task.Exception != null)
       {
         throw task.Exception;
       }
 
-      throw e;
+      throw;
     }
 
     return (

--- a/src/Ardalis.Extensions/Tasks/WhenAll.cs
+++ b/src/Ardalis.Extensions/Tasks/WhenAll.cs
@@ -120,4 +120,23 @@ public static partial class TasksExtensions
       tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result, 
       tasks.Item6.Result, tasks.Item7.Result, tasks.Item8.Result);
   }
+
+  public static async Task<(T1, T2, T3, T4, T5, T6, T7, T8, T9)> WhenAll<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+    this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>, Task<T7>, Task<T8>, Task<T9>) tasks)
+  {
+    var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6,
+      tasks.Item7, tasks.Item8);
+    try 
+    {
+      await task;
+    }
+    catch (Exception)
+    {
+      throw task.Exception;
+    }
+    
+    return (
+      tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result, tasks.Item5.Result, 
+      tasks.Item6.Result, tasks.Item7.Result, tasks.Item8.Result, tasks.Item9.Result);
+  }
 }

--- a/src/Ardalis.Extensions/Tasks/WhenAll.cs
+++ b/src/Ardalis.Extensions/Tasks/WhenAll.cs
@@ -11,4 +11,10 @@ public static partial class TasksExtensions
     await Task.WhenAll(tasks.Item1, tasks.Item2);
     return (tasks.Item1.Result, tasks.Item2.Result);
   }
+
+  public static async Task<(T1, T2, T3)> WhenAll<T1, T2, T3>(this (Task<T1>, Task<T2>, Task<T3>) tasks)
+  {
+    await Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3);
+    return (tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result);
+  }
 }

--- a/src/Ardalis.Extensions/Tasks/WhenAll.cs
+++ b/src/Ardalis.Extensions/Tasks/WhenAll.cs
@@ -8,14 +8,22 @@ public static partial class TasksExtensions
 
   public static async Task<(T1, T2)> WhenAll<T1, T2>(this (Task<T1>, Task<T2>) tasks)
   {
-    await Task.WhenAll(tasks.Item1, tasks.Item2);
+    var task = Task.WhenAll(tasks.Item1, tasks.Item2);
+    try 
+    {
+      await task;
+    } catch (Exception) {
+      throw task.Exception;
+    }
+
     return (tasks.Item1.Result, tasks.Item2.Result);
   }
 
   public static async Task<(T1, T2, T3)> WhenAll<T1, T2, T3>(this (Task<T1>, Task<T2>, Task<T3>) tasks)
   {
     var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3);
-    try {
+    try 
+    {
       await task;
     }
     catch (Exception)
@@ -24,5 +32,20 @@ public static partial class TasksExtensions
     }
     
     return (tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result);
+  }
+
+  public static async Task<(T1, T2, T3, T4)> WhenAll<T1, T2, T3, T4>(this (Task<T1>, Task<T2>, Task<T3>, Task<T4>) tasks)
+  {
+    var task = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3);
+    try 
+    {
+      await task;
+    }
+    catch (Exception)
+    {
+      throw task.Exception;
+    }
+    
+    return (tasks.Item1.Result, tasks.Item2.Result, tasks.Item3.Result, tasks.Item4.Result);
   }
 }

--- a/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
@@ -11,24 +11,22 @@ public class WhenAllTests
   private readonly string _expectedString = "test";
 
   [Fact]
-  public async Task TakesTupleOfOneTaskAndReturnsTupleOfOneResult()
+  public async Task TakesTupleOfTwoTaskAndReturnsTupleOfOneResult()
   {
-    var tasks = Tuple.Create(GetIntAsync());
+    var tasks = (GetIntAsync(), GetStringAsync());
 
     var result = await tasks.WhenAll();
 
-    Assert.Equal(_expectedInt, result.Item1);
+    Assert.Equal((_expectedInt, _expectedString), result);
   }
 
-  private async Task<int> GetIntAsync()
+  private Task<int> GetIntAsync()
   {
-    await Task.Delay(1);
-    return _expectedInt;
+    return Task.FromResult(_expectedInt);
   }
 
-  private async Task<string> GetStringAsync()
+  private Task<string> GetStringAsync()
   {
-    await Task.Delay(1);
-    return _expectedString;
+    return Task.FromResult(_expectedString);
   }
 }

--- a/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
@@ -9,15 +9,26 @@ public class WhenAllTests
 {
   private readonly int _expectedInt = 1;
   private readonly string _expectedString = "test";
+  private readonly DateTime _expectedDateTime = new DateTime(2022, 1, 1);
 
   [Fact]
-  public async Task TakesTupleOfTwoTaskAndReturnsTupleOfOneResult()
+  public async Task TakesTupleOfTwoTasksAndReturnsTupleOfTwoResult()
   {
     var tasks = (GetIntAsync(), GetStringAsync());
 
     var result = await tasks.WhenAll();
 
     Assert.Equal((_expectedInt, _expectedString), result);
+  }
+
+  [Fact]
+  public async Task TakesTupleOfThreeTasksAndReturnsTupleOfThreeResult()
+  {
+    var tasks = (GetIntAsync(), GetStringAsync(), GetDateTimeAsync());
+
+    var result = await tasks.WhenAll();
+
+    Assert.Equal((_expectedInt, _expectedString, _expectedDateTime), result);
   }
 
   private Task<int> GetIntAsync()
@@ -28,5 +39,10 @@ public class WhenAllTests
   private Task<string> GetStringAsync()
   {
     return Task.FromResult(_expectedString);
+  }
+
+  private Task<DateTime> GetDateTimeAsync()
+  {
+    return Task.FromResult(_expectedDateTime);
   }
 }

--- a/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading.Tasks;
+using Ardalis.Extensions.Tasks;
+using Xunit;
+
+namespace Ardalis.Extensions.UnitTests.Tasks;
+
+public class WhenAllTests
+{
+  private readonly int _expectedInt = 1;
+  private readonly string _expectedString = "test";
+
+  [Fact]
+  public async Task TakesTupleOfOneTaskAndReturnsTupleOfOneResult()
+  {
+    var tasks = Tuple.Create(GetIntAsync());
+
+    var result = await tasks.WhenAll();
+
+    Assert.Equal(_expectedInt, result.Item1);
+  }
+
+  private async Task<int> GetIntAsync()
+  {
+    await Task.Delay(1);
+    return _expectedInt;
+  }
+
+  private async Task<string> GetStringAsync()
+  {
+    await Task.Delay(1);
+    return _expectedString;
+  }
+}

--- a/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
@@ -53,7 +53,7 @@ public class WhenAllTests
   public async Task TakesTupleOfSixTasksAndReturnsTupleOfSixResult()
   {
     var tasks = (
-      GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"), 
+      GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"),
       GetDateTimeAsync(6));
 
     var result = await tasks.WhenAll();
@@ -65,7 +65,7 @@ public class WhenAllTests
   public async Task TakesTupleOfSevenTasksAndReturnsTupleOfSevenResult()
   {
     var tasks = (
-      GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"), 
+      GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"),
       GetDateTimeAsync(6), GetIntAsync(7));
 
     var result = await tasks.WhenAll();
@@ -77,7 +77,7 @@ public class WhenAllTests
   public async Task TakesTupleOfEightTasksAndReturnsTupleOfEightResult()
   {
     var tasks = (
-      GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"), 
+      GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"),
       GetDateTimeAsync(6), GetIntAsync(7), GetStringAsync("Eight"));
 
     var result = await tasks.WhenAll();
@@ -89,7 +89,7 @@ public class WhenAllTests
   public async Task TakesTupleOfNineTasksAndReturnsTupleOfNineResult()
   {
     var tasks = (
-      GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"), 
+      GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"),
       GetDateTimeAsync(6), GetIntAsync(7), GetStringAsync("Eight"), GetDateTimeAsync(9));
 
     var result = await tasks.WhenAll();
@@ -101,7 +101,7 @@ public class WhenAllTests
   public async Task TakesTupleOfTenTasksAndReturnsTupleOfTenResult()
   {
     var tasks = (
-      GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"), 
+      GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"),
       GetDateTimeAsync(6), GetIntAsync(7), GetStringAsync("Eight"), GetDateTimeAsync(9), GetIntAsync(10));
 
     var result = await tasks.WhenAll();
@@ -115,6 +115,22 @@ public class WhenAllTests
     var tasks = (GetIntAsync(1), GetExceptionAsync(), GetDateTimeAsync(3));
 
     await Assert.ThrowsAsync<AggregateException>(() => tasks.WhenAll());
+  }
+
+  [Fact]
+  public async Task ResultsInFaultedStateWhenATaskThrows()
+  {
+    var tasks = (GetIntAsync(1), GetExceptionAsync(), GetDateTimeAsync(3));
+
+    try
+    {
+      await tasks.WhenAll();
+      throw new Exception("Should not reach here");
+    }
+    catch (AggregateException)
+    {
+      Assert.True(tasks.Item2.IsFaulted);
+    }
   }
 
   [Fact]
@@ -136,11 +152,28 @@ public class WhenAllTests
   }
 
   [Fact]
-  public async Task ResultsInCancelledStateWhenOneTaskIsCancelled()
+  public async Task ThrowsACancelledExceptionWhenOneTaskIsCancelled()
   {
     var tasks = (GetIntAsync(1), GetCancelledAsync(), GetIntAsync(3));
 
     var exception = await Assert.ThrowsAsync<TaskCanceledException>(() => tasks.WhenAll());
+  }
+
+  [Fact]
+  public async Task ResultsInCancelledStateWhenOneTaskIsCancelled()
+  {
+    var tasks = (GetIntAsync(1), GetCancelledAsync(), GetIntAsync(3));
+
+    var result = tasks.WhenAll();
+    try
+    {
+      await result;
+      throw new Exception("Should not get here");
+    }
+    catch (TaskCanceledException)
+    {
+      Assert.Equal(TaskStatus.Canceled, result.Status);
+    }
   }
 
   private Task<int> GetIntAsync(int value)

--- a/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
@@ -73,6 +73,18 @@ public class WhenAllTests
   }
 
   [Fact]
+  public async Task TakesTupleOfEightTasksAndReturnsTupleOfEightResult()
+  {
+    var tasks = (
+      GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"), 
+      GetDateTimeAsync(6), GetIntAsync(7), GetStringAsync("Eight"));
+
+    var result = await tasks.WhenAll();
+
+    Assert.Equal((1, "Two", new DateTime(3), 4, "Five", new DateTime(6), 7, "Eight"), result);
+  }
+
+  [Fact]
   public async Task ThrowsWhenATaskThrows()
   {
     var tasks = (GetIntAsync(1), GetExceptionAsync(), GetDateTimeAsync(3));

--- a/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
@@ -49,6 +49,18 @@ public class WhenAllTests
   }
 
   [Fact]
+  public async Task TakesTupleOfSixTasksAndReturnsTupleOfSixResult()
+  {
+    var tasks = (
+      GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"), GetDateTimeAsync(6)
+      );
+
+    var result = await tasks.WhenAll();
+
+    Assert.Equal((1, "Two", new DateTime(3), 4, "Five", new DateTime(6)), result);
+  }
+
+  [Fact]
   public async Task ThrowsWhenATaskThrows()
   {
     var tasks = (GetIntAsync(1), GetExceptionAsync(), GetDateTimeAsync(3));

--- a/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
@@ -85,6 +85,18 @@ public class WhenAllTests
   }
 
   [Fact]
+  public async Task TakesTupleOfNineTasksAndReturnsTupleOfNineResult()
+  {
+    var tasks = (
+      GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"), 
+      GetDateTimeAsync(6), GetIntAsync(7), GetStringAsync("Eight"), GetDateTimeAsync(9));
+
+    var result = await tasks.WhenAll();
+
+    Assert.Equal((1, "Two", new DateTime(3), 4, "Five", new DateTime(6), 7, "Eight", new DateTime(9)), result);
+  }
+
+  [Fact]
   public async Task ThrowsWhenATaskThrows()
   {
     var tasks = (GetIntAsync(1), GetExceptionAsync(), GetDateTimeAsync(3));

--- a/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Ardalis.Extensions.Tasks;
 using Xunit;
@@ -134,6 +135,14 @@ public class WhenAllTests
     var exception = await Assert.ThrowsAsync<ArgumentException>(() => tasks.WhenAll());
   }
 
+  [Fact]
+  public async Task ResultsInCancelledStateWhenOneTaskIsCancelled()
+  {
+    var tasks = (GetIntAsync(1), GetCancelledAsync(), GetIntAsync(3));
+
+    var exception = await Assert.ThrowsAsync<TaskCanceledException>(() => tasks.WhenAll());
+  }
+
   private Task<int> GetIntAsync(int value)
   {
     return Task.FromResult(value);
@@ -157,6 +166,19 @@ public class WhenAllTests
       if (i == 2)
       {
         throw new Exception(message);
+      }
+    }
+    return 44;
+  }
+
+  private async Task<int> GetCancelledAsync()
+  {
+    for (var i = 0; i <= 10; i++)
+    {
+      await Task.Delay(1);
+      if (i == 2)
+      {
+        return await Task.FromCanceled<int>(new CancellationToken(true));
       }
     }
     return 44;

--- a/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
@@ -31,6 +31,14 @@ public class WhenAllTests
     Assert.Equal((_expectedInt, _expectedString, _expectedDateTime), result);
   }
 
+  [Fact]
+  public async Task ThrowsWhenATaskThrows()
+  {
+    var tasks = (GetIntAsync(), GetExceptionAsync(1), GetDateTimeAsync());
+
+    await Assert.ThrowsAsync<WhenAllException>( () => tasks.WhenAll());
+  }
+
   private Task<int> GetIntAsync()
   {
     return Task.FromResult(_expectedInt);
@@ -44,5 +52,25 @@ public class WhenAllTests
   private Task<DateTime> GetDateTimeAsync()
   {
     return Task.FromResult(_expectedDateTime);
+  }
+
+  private async Task<int> GetExceptionAsync(int milliseconds)
+  { 
+    for (var i = 0; i <= milliseconds; i++)
+    {
+      await Task.Delay(1);
+      if (i == milliseconds)
+      {
+        throw new WhenAllException("OMG, an exception!");
+      }
+    }
+    return 44;
+  }
+}
+
+class WhenAllException : Exception
+{
+  public WhenAllException(string message) : base(message)
+  {
   }
 }

--- a/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
@@ -78,6 +78,14 @@ public class WhenAllTests
     Assert.Equal("Second", exception.InnerExceptions[1].Message);
   }
 
+  [Fact]
+  public async Task ThrowsWhenTheTasksTupleContainedANullTask()
+  {
+    (Task<int>, Task<string>, Task<DateTime>) tasks = (GetExceptionAsync("First"), null, GetDateTimeAsync(3));
+
+    var exception = await Assert.ThrowsAsync<ArgumentException>(() => tasks.WhenAll());
+  }
+
   private Task<int> GetIntAsync(int value)
   {
     return Task.FromResult(value);

--- a/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
@@ -39,6 +39,16 @@ public class WhenAllTests
   }
 
   [Fact]
+  public async Task TakesTupleOfFiveTasksAndReturnsTupleOfFiveResult()
+  {
+    var tasks = (GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"));
+
+    var result = await tasks.WhenAll();
+
+    Assert.Equal((1, "Two", new DateTime(3), 4, "Five"), result);
+  }
+
+  [Fact]
   public async Task ThrowsWhenATaskThrows()
   {
     var tasks = (GetIntAsync(1), GetExceptionAsync(), GetDateTimeAsync(3));

--- a/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
@@ -7,34 +7,41 @@ namespace Ardalis.Extensions.UnitTests.Tasks;
 
 public class WhenAllTests
 {
-  private readonly int _expectedInt = 1;
-  private readonly string _expectedString = "test";
-  private readonly DateTime _expectedDateTime = new DateTime(2022, 1, 1);
 
   [Fact]
   public async Task TakesTupleOfTwoTasksAndReturnsTupleOfTwoResult()
   {
-    var tasks = (GetIntAsync(), GetStringAsync());
+    var tasks = (GetIntAsync(1), GetStringAsync("Two"));
 
     var result = await tasks.WhenAll();
 
-    Assert.Equal((_expectedInt, _expectedString), result);
+    Assert.Equal((1, "Two"), result);
   }
 
   [Fact]
   public async Task TakesTupleOfThreeTasksAndReturnsTupleOfThreeResult()
   {
-    var tasks = (GetIntAsync(), GetStringAsync(), GetDateTimeAsync());
+    var tasks = (GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3));
 
     var result = await tasks.WhenAll();
 
-    Assert.Equal((_expectedInt, _expectedString, _expectedDateTime), result);
+    Assert.Equal((1, "Two", new DateTime(3)), result);
+  }
+
+  [Fact]
+  public async Task TakesTupleOfFourTasksAndReturnsTupleOfFourResult()
+  {
+    var tasks = (GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4));
+
+    var result = await tasks.WhenAll();
+
+    Assert.Equal((1, "Two", new DateTime(3), 4), result);
   }
 
   [Fact]
   public async Task ThrowsWhenATaskThrows()
   {
-    var tasks = (GetIntAsync(), GetExceptionAsync(), GetDateTimeAsync());
+    var tasks = (GetIntAsync(1), GetExceptionAsync(), GetDateTimeAsync(3));
 
     await Assert.ThrowsAsync<AggregateException>(() => tasks.WhenAll());
   }
@@ -42,26 +49,26 @@ public class WhenAllTests
   [Fact]
   public async Task ThrowsWhenMoreThanOneTaskThrows()
   {
-    var tasks = (GetExceptionAsync("First"), GetExceptionAsync("Second"), GetDateTimeAsync());
+    var tasks = (GetExceptionAsync("First"), GetExceptionAsync("Second"), GetDateTimeAsync(3));
 
     var exception = await Assert.ThrowsAsync<AggregateException>(() => tasks.WhenAll());
     Assert.Equal("First", exception.InnerExceptions[0].Message);
     Assert.Equal("Second", exception.InnerExceptions[1].Message);
   }
 
-  private Task<int> GetIntAsync()
+  private Task<int> GetIntAsync(int value)
   {
-    return Task.FromResult(_expectedInt);
+    return Task.FromResult(value);
   }
 
-  private Task<string> GetStringAsync()
+  private Task<string> GetStringAsync(string value)
   {
-    return Task.FromResult(_expectedString);
+    return Task.FromResult(value);
   }
 
-  private Task<DateTime> GetDateTimeAsync()
+  private Task<DateTime> GetDateTimeAsync(long value)
   {
-    return Task.FromResult(_expectedDateTime);
+    return Task.FromResult(new DateTime(value));
   }
 
   private async Task<int> GetExceptionAsync(string message = null)
@@ -71,16 +78,9 @@ public class WhenAllTests
       await Task.Delay(1);
       if (i == 2)
       {
-        throw new WhenAllException(message);
+        throw new Exception(message);
       }
     }
     return 44;
-  }
-}
-
-class WhenAllException : Exception
-{
-  public WhenAllException(string message) : base(message)
-  {
   }
 }

--- a/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
@@ -52,12 +52,24 @@ public class WhenAllTests
   public async Task TakesTupleOfSixTasksAndReturnsTupleOfSixResult()
   {
     var tasks = (
-      GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"), GetDateTimeAsync(6)
-      );
+      GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"), 
+      GetDateTimeAsync(6));
 
     var result = await tasks.WhenAll();
 
     Assert.Equal((1, "Two", new DateTime(3), 4, "Five", new DateTime(6)), result);
+  }
+
+  [Fact]
+  public async Task TakesTupleOfSevenTasksAndReturnsTupleOfSevenResult()
+  {
+    var tasks = (
+      GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"), 
+      GetDateTimeAsync(6), GetIntAsync(7));
+
+    var result = await tasks.WhenAll();
+
+    Assert.Equal((1, "Two", new DateTime(3), 4, "Five", new DateTime(6), 7), result);
   }
 
   [Fact]

--- a/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Tasks/WhenAllTests.cs
@@ -97,6 +97,18 @@ public class WhenAllTests
   }
 
   [Fact]
+  public async Task TakesTupleOfTenTasksAndReturnsTupleOfTenResult()
+  {
+    var tasks = (
+      GetIntAsync(1), GetStringAsync("Two"), GetDateTimeAsync(3), GetIntAsync(4), GetStringAsync("Five"), 
+      GetDateTimeAsync(6), GetIntAsync(7), GetStringAsync("Eight"), GetDateTimeAsync(9), GetIntAsync(10));
+
+    var result = await tasks.WhenAll();
+
+    Assert.Equal((1, "Two", new DateTime(3), 4, "Five", new DateTime(6), 7, "Eight", new DateTime(9), 10), result);
+  }
+
+  [Fact]
   public async Task ThrowsWhenATaskThrows()
   {
     var tasks = (GetIntAsync(1), GetExceptionAsync(), GetDateTimeAsync(3));


### PR DESCRIPTION
I implemented a WhenAll() extension method for tuples containing Tasks of various types and of length <= 10. It returns a tuple with the corresponding result values.

### Motivation
The built-in Task.WhenAll method overloads only work with IEnumerable and is awkward to work with when dealing with Tasks that return different values, leading to code like this:

```cs
var getCarTask = GetCarAsync();
var getDogTask = GetDogAsync();
var getHouseTask = GetHouseAsync();

var task = Task.WhenAll(getCarTask, getDogTask, getHouseTask);
try
{
  await task;
}
catch (Exception e)
{
  if (task.Exception != null)
  {
    throw task.Exception;
  }
  throw e;
}

Assert.IsType<Car>(car.Result);
Assert.IsType<Dog>(dog.Result);
Assert.IsType<House>(house.Result);
```

Part of the reason why we have to structure the code this way is that it is necessary in order to get proper exception information when more than one task throws or is cancelled. But even if we didn't bother with error handling, the fact that we have to save the tasks in their individual variables and await their result later, after having called `WhenAll` is counter-intuitive. It is confusing because in the case of a collection of Tasks of the same type, you can simply do this:

```cs
Car[] result = await Task.WhenAll(getCar(1), getCar(2), getCar(3));

Assert.Equal(1, result[0].id)
Assert.Equal(2, result[1].id)
Assert.Equal(3, result[2].id)
```
Which is much better, but could still be improved if it was possible to destructure arrays, which at the moment is not possible in C#. But it is possible to destructure tuples. Plus, tuples can hold values of different types. Which is why I chose the tuple type as the input and return type of my implementation.

### Example use
```cs
var (car, dog, house) = await (GetCarAsync(), GetDogAsync(), GetHouseAsync()).WhenAll();

Assert.IsType<Car>(car);
Assert.IsType<Dog>(dog);
Assert.IsType<House>(house);
```