### PR TITLE
added table of contents in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@ Some random C# extension methods I've found useful. Published as Ardalis.Extensi
 
 ## Table of Contents
 
-TODO. A PR would be nice here.
+- [Installation](#installation)
+- [Usage](#usage)
+   - [String checks](#string-checks)
+- [Conventions for Contributors](conventions-for-contributors)
+- [Benchmarks](benchmarks)
+- [Roadmap](roadmap)
 
 ## Installation
 
@@ -49,7 +54,6 @@ if(String.IsNullOrWhiteSpace(someString))
 
 // with
 if(someString.IsNullOrWhiteSpace())
-```
 ```
 
 ## Conventions for Contributors


### PR DESCRIPTION
- Added table of contents
- The section "convention for contributors" and "roadmap" were included in a code block. I went ahead and fixed it. Sorry if it was an intentional issue aimed at other beginner contributors but the table of contents would not detect that particular hyperlink if it was enclosed in a code block.