### PR TITLE
Allow looping over ranges

### DIFF
--- a/benchmarks/Ardalis.Extensions.Benchmarks/Enumerable/RangeEnumeratorBenchmarks.cs
+++ b/benchmarks/Ardalis.Extensions.Benchmarks/Enumerable/RangeEnumeratorBenchmarks.cs
@@ -29,8 +29,8 @@ public class RangeEnumeratorBenchmarks
   }
 
   /// <summary>
-  /// Prevent the compiler from optimizing away the loop
+  /// Prevent the compiler from optimizing away loop enumeration.
   /// </summary>
-  /// <param name="i"></param>
+  /// <param name="i">Current loop value</param>
   private static void DoNotOptimizeAway(int i) { }
 }

--- a/benchmarks/Ardalis.Extensions.Benchmarks/Enumerable/RangeEnumeratorBenchmarks.cs
+++ b/benchmarks/Ardalis.Extensions.Benchmarks/Enumerable/RangeEnumeratorBenchmarks.cs
@@ -15,7 +15,7 @@ public class RangeEnumeratorBenchmarks
   {
     for (int i = 0; i < End; i++)
     {
-      DoSomething(i);
+      DoNotOptimizeAway(i);
     }
   }
   
@@ -24,10 +24,13 @@ public class RangeEnumeratorBenchmarks
   {
     foreach(var i in 0..End)
     {
-      DoSomething(i);
+      DoNotOptimizeAway(i);
     }
   }
 
-  // Prevent the compiler from optimizing away the loop
-  private static void DoSomething(int i) { }
+  /// <summary>
+  /// Prevent the compiler from optimizing away the loop
+  /// </summary>
+  /// <param name="i"></param>
+  private static void DoNotOptimizeAway(int i) { }
 }

--- a/benchmarks/Ardalis.Extensions.Benchmarks/Enumerable/RangeEnumeratorBenchmarks.cs
+++ b/benchmarks/Ardalis.Extensions.Benchmarks/Enumerable/RangeEnumeratorBenchmarks.cs
@@ -1,0 +1,33 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ardalis.Extensions.Enumerable;
+
+namespace Ardalis.Extensions.Benchmarks.Enumerable;
+
+[MemoryDiagnoser]
+[ReturnValueValidator(failOnError: true)]
+public class RangeEnumeratorBenchmarks
+{
+  [Params(10, 1000, 10000)]
+  public int End { get; set; }
+
+  [Benchmark(Baseline = true)]
+  public void NormalForLoop()
+  {
+    for (int i = 0; i < End; i++)
+    {
+      DoSomething(i);
+    }
+  }
+  
+  [Benchmark]
+  public void RangedForLoop()
+  {
+    foreach(var i in 0..End)
+    {
+      DoSomething(i);
+    }
+  }
+
+  // Prevent the compiler from optimizing away the loop
+  private static void DoSomething(int i) { }
+}

--- a/src/Ardalis.Extensions/Enumerable/RangeEnumerator.cs
+++ b/src/Ardalis.Extensions/Enumerable/RangeEnumerator.cs
@@ -44,8 +44,14 @@ public static partial class EnumerableExtensions
 
     public bool MoveNext()
     {
+      // prevent overflow if the end value is int.MaxValue
+      if (_current == int.MaxValue)
+      {
+        return false;
+      }
+
       _current++;
-      return _current < _end;
+      return _current <= _end;
     }
   }
 }

--- a/src/Ardalis.Extensions/Enumerable/RangeEnumerator.cs
+++ b/src/Ardalis.Extensions/Enumerable/RangeEnumerator.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace Ardalis.Extensions.Enumerable;
+
+public static partial class EnumerableExtensions
+{
+  public static RangeEnumerator GetEnumerator(this Range range)
+  {
+    return new RangeEnumerator(range);
+  }
+
+  public static RangeEnumerator GetEnumerator(this int number)
+  {
+    return new RangeEnumerator(new Range(0, number));
+  }
+
+  public ref struct RangeEnumerator
+  {
+    private int _current;
+    private readonly int _end;
+
+    public RangeEnumerator(Range range)
+    {
+      if (range.End.IsFromEnd)
+      {
+        throw new NotSupportedException();
+      }
+
+      _current = range.Start.Value - 1;
+      _end = range.End.Value;
+    }
+
+    public int Current => _current;
+
+    public bool MoveNext()
+    {
+      _current++;
+      return _current < _end;
+    }
+  }
+}

--- a/src/Ardalis.Extensions/Enumerable/RangeEnumerator.cs
+++ b/src/Ardalis.Extensions/Enumerable/RangeEnumerator.cs
@@ -4,16 +4,26 @@ namespace Ardalis.Extensions.Enumerable;
 
 public static partial class EnumerableExtensions
 {
-  public static RangeEnumerator GetEnumerator(this Range range)
-  {
-    return new RangeEnumerator(range);
-  }
+  /// <summary>
+  /// Defines an extension method to get a <see cref="RangeEnumerator"/> from a <see cref="Range"/>
+  /// that can be used in a foreach loop.
+  /// </summary>
+  /// <param name="range">Range over which to generate the enumerator</param>
+  /// <returns>Enumerator over the given range</returns>
+  public static RangeEnumerator GetEnumerator(this Range range) => new(range);
 
-  public static RangeEnumerator GetEnumerator(this int number)
-  {
-    return new RangeEnumerator(new Range(0, number));
-  }
+  /// <summary>
+  /// Defines an extension method to get a <see cref="RangeEnumerator"/> from an <see cref="int"/>
+  /// that can be used in a foreach loop.
+  /// </summary>
+  /// <param name="number">Ending number in the range</param>
+  /// <returns>Enumerator over a range from 0 to <paramref name="number"/></returns>
+  public static RangeEnumerator GetEnumerator(this int number) => new(new Range(0, number));
 
+  /// <summary>
+  /// Custom enumerator for a <see cref="Range"/> that can be used in a foreach loop.
+  /// This type is meant to reduce allocations and act like an <see cref="IEnumerator"/> via duck typing.
+  /// </summary>
   public ref struct RangeEnumerator
   {
     private int _current;
@@ -30,7 +40,7 @@ public static partial class EnumerableExtensions
       _end = range.End.Value;
     }
 
-    public int Current => _current;
+    public readonly int Current => _current;
 
     public bool MoveNext()
     {

--- a/tests/Ardalis.Extensions.UnitTests/Enumerable/RangeEnumeratorTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Enumerable/RangeEnumeratorTests.cs
@@ -67,6 +67,9 @@ public class RangeEnumeratorTests
       Assert.Equal(counter, i);
       counter++;
     }
+
+    // ensure we are inclusive of the end
+    Assert.Equal(counter - 1, end);
   }
   
   [Theory]
@@ -81,6 +84,9 @@ public class RangeEnumeratorTests
       Assert.Equal(counter, i);
       counter++;
     }
+
+    // ensure we are inclusive of the end
+    Assert.Equal(counter - 1, end);
   }
 
   [Theory]
@@ -95,5 +101,8 @@ public class RangeEnumeratorTests
       Assert.Equal(counter, i);
       counter++;
     }
+
+    // ensure we are inclusive of the end
+    Assert.Equal(counter - 1, end);
   }
 }

--- a/tests/Ardalis.Extensions.UnitTests/Enumerable/RangeEnumeratorTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Enumerable/RangeEnumeratorTests.cs
@@ -15,7 +15,7 @@ public class RangeEnumeratorTests
       foreach (int i in -10..0) { }
     });
   }
-  
+
   [Fact]
   public void Foreach_EndIsNegative_ThrowsOutOfRange()
   {
@@ -44,16 +44,20 @@ public class RangeEnumeratorTests
       Assert.True(false, "A range where the end is less than the start should yield no iterations.");
     }
   }
-  
-  [Fact]
-  public void Foreach_StartEqualsEnd_NoIteration()
+
+  [Theory]
+  [InlineData(0, 0)]
+  [InlineData(1000, 1000)]
+  [InlineData(int.MaxValue, int.MaxValue)]
+  public void Foreach_StartEqualsEnd_OneIteration(int start, int end)
   {
-    foreach (var i in 0..0)
+    // because we are inclusive of the end value, e.g. 0..0 should yield 1 iteration with value 0
+    foreach (var i in start..end)
     {
-      Assert.True(false, "A range where the start and end are equal should yield no iterations.");
+      Assert.Equal(start, i);
     }
   }
-  
+
   [Theory]
   [InlineData(0, 10)]
   [InlineData(0, 1000)]
@@ -71,12 +75,12 @@ public class RangeEnumeratorTests
     // ensure we are inclusive of the end
     Assert.Equal(counter - 1, end);
   }
-  
+
   [Theory]
   [InlineData(10)]
   [InlineData(1000)]
   [InlineData(100000)]
-  public void Foreach_DotDotToEnd_IteratesAsExpected(int end)
+  public void Foreach_DotDotToEnd_IteratesFromZeroAsExpected(int end)
   {
     int counter = 0;
     foreach (var i in ..end)
@@ -93,7 +97,7 @@ public class RangeEnumeratorTests
   [InlineData(10)]
   [InlineData(1000)]
   [InlineData(100000)]
-  public void Foreach_ToEnd_IteratesAsExpected(int end)
+  public void Foreach_ToEnd_IteratesFromZeroAsExpected(int end)
   {
     int counter = 0;
     foreach (var i in end)

--- a/tests/Ardalis.Extensions.UnitTests/Enumerable/RangeEnumeratorTests.cs
+++ b/tests/Ardalis.Extensions.UnitTests/Enumerable/RangeEnumeratorTests.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using Ardalis.Extensions.Enumerable;
+using Xunit;
+
+namespace Ardalis.Extensions.UnitTests.Enumerables;
+
+public class RangeEnumeratorTests
+{
+  [Fact]
+  public void Foreach_StartIsNegative_ThrowsOutOfRange()
+  {
+    // implict creation of a Range uses Index which requires a non-negative value
+    Assert.Throws<ArgumentOutOfRangeException>(() =>
+    {
+      foreach (int i in -10..0) { }
+    });
+  }
+  
+  [Fact]
+  public void Foreach_EndIsNegative_ThrowsOutOfRange()
+  {
+    // implict creation of a Range uses Index which requires a non-negative value
+    Assert.Throws<ArgumentOutOfRangeException>(() =>
+    {
+      foreach (int i in 0..-1) { }
+    });
+  }
+
+  [Fact]
+  public void Foreach_EndIsFromEnd_ThrowsNotSupported()
+  {
+    Assert.Throws<NotSupportedException>(() =>
+    {
+      foreach (int i in 0..^5) { }
+    });
+  }
+
+  [Fact]
+  public void Foreach_EndIsLessThanStart_NoIteration()
+  {
+    foreach (var i in 5..2)
+    {
+      // fail if we get here
+      Assert.True(false, "A range where the end is less than the start should yield no iterations.");
+    }
+  }
+  
+  [Fact]
+  public void Foreach_StartEqualsEnd_NoIteration()
+  {
+    foreach (var i in 0..0)
+    {
+      Assert.True(false, "A range where the start and end are equal should yield no iterations.");
+    }
+  }
+  
+  [Theory]
+  [InlineData(0, 10)]
+  [InlineData(0, 1000)]
+  [InlineData(0, 100000)]
+  [InlineData(int.MaxValue - 1, int.MaxValue)]
+  public void Foreach_StartToEnd_IteratesAsExpected(int start, int end)
+  {
+    int counter = start;
+    foreach (var i in start..end)
+    {
+      Assert.Equal(counter, i);
+      counter++;
+    }
+  }
+  
+  [Theory]
+  [InlineData(10)]
+  [InlineData(1000)]
+  [InlineData(100000)]
+  public void Foreach_DotDotToEnd_IteratesAsExpected(int end)
+  {
+    int counter = 0;
+    foreach (var i in ..end)
+    {
+      Assert.Equal(counter, i);
+      counter++;
+    }
+  }
+
+  [Theory]
+  [InlineData(10)]
+  [InlineData(1000)]
+  [InlineData(100000)]
+  public void Foreach_ToEnd_IteratesAsExpected(int end)
+  {
+    int counter = 0;
+    foreach (var i in end)
+    {
+      Assert.Equal(counter, i);
+      counter++;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #60 

Some design considerations:
- It is not possible to specify negative numbers e.g. `foreach (var i in -10..0)` due to limitations with the implicit creation of `Index` from `Range`
- The range is inclusive of the end so `foreach(var i in 0..10)` will yield `[0, 1, ..., 10]` which is equivalent to `for(var i = 0; i <= 10; i++)`
- Since the end is inclusive, a range where the start and end are equal will yield 1 value e.g. `foreach (var i in 0..0)` will iterate once with `i == 0`